### PR TITLE
Dummy Functions for LengthValue and SimpleLength

### DIFF
--- a/src/length-value.js
+++ b/src/length-value.js
@@ -1,0 +1,79 @@
+// Copyright 2015 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//     You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//     See the License for the specific language governing permissions and
+// limitations under the License.
+
+(function(shared, testing) {
+
+  function LengthValue() {
+  }
+
+  /**
+   * The different possible length types.
+   * NOTE: Must use uppercase as 'in' is a reserved word.
+   * @enum {string}
+   */
+  LengthValue.LengthType = {
+    PX: 'px',
+    PERCENT: 'percent',
+    EM: 'em',
+    EX: 'ex',
+    CH: 'ch',
+    REM: 'rem',
+    VW: 'vw',
+    VH: 'vh',
+    VMIN: 'vmin',
+    VMAX: 'vmax',
+    CM: 'cm',
+    MM: 'mm',
+    Q: 'q',
+    IN: 'in',
+    PC: 'pc',
+    PT: 'pt'
+  };
+
+  LengthValue.prototype = Object.create(shared.StyleValue.prototype);
+
+  // Length Calculation Methods
+  LengthValue.prototype.add = function(value) {
+    throw new TypeError('Not implemented yet');
+  };
+
+  LengthValue.prototype.subtract = function(value) {
+    throw new TypeError('Not implemented yet');
+  };
+
+  LengthValue.prototype.multiply = function(value) {
+    throw new TypeError('Not implemented yet');
+  };
+
+  LengthValue.prototype.divide = function(value) {
+    throw new TypeError('Not implemented yet');
+  };
+
+  LengthValue.prototype.parse = function(cssString) {
+    throw new TypeError('Not implemented yet');
+  };
+
+  LengthValue.prototype.fromValue = function(value, type) {
+    throw new TypeError('Not implemented yet');
+  };
+
+  LengthValue.prototype.fromDictionary = function(dictionary) {
+    throw new TypeError('Not implemented yet');
+  };
+
+  shared.LengthValue = LengthValue;
+  if (TYPED_OM_TESTING)
+    testing.LengthValue = LengthValue;
+
+})(baseClasses, typedOMTesting);

--- a/src/simple-length.js
+++ b/src/simple-length.js
@@ -1,0 +1,47 @@
+// Copyright 2015 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//     You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//     See the License for the specific language governing permissions and
+// limitations under the License.
+
+(function(shared, scope, testing) {
+
+  /**
+   * SimpleLength(value, type)
+   * TODO: SimpleLength(simpleLength), SimpleLength(cssString)
+   *
+   * @constructor
+   */
+  function SimpleLength(value, type) {
+    if (arguments.length == 2 && typeof type == 'string' &&
+      type.toUpperCase() in LengthValue.LengthType) {
+      this.type = LengthValue.LengthType[type.toUpperCase()];
+      if (typeof value == 'number') {
+        this.value = value;
+      } else if (typeof value == 'string') {
+        nValue = Number.parseFloat(value);
+        if (!isNaN(nValue)) {
+          this.value = nValue;
+        }
+      }
+    }
+    if (this.value == undefined) {
+      throw(new TypeError('Value of SimpleLength must be a number or a numeric string.'));
+    }
+  }
+
+  SimpleLength.prototype = shared.LengthValue.prototype;
+
+  scope.SimpleLength = SimpleLength;
+  if (TYPED_OM_TESTING)
+    testing.SimpleLength = SimpleLength;
+
+})(baseClasses, window, typedOMTesting);

--- a/target-config.js
+++ b/target-config.js
@@ -21,12 +21,15 @@
   var typedOMSrc = [
       'src/style-value.js',
       'src/number-value.js',
+      'src/length-value.js',
+      'src/simple-length.js',
       'src/style-property-map.js',
       'src/computed-style-property-map.js'
   ];
 
   var typedOMTest = [
       'test/js/number-value.js',
+      'test/js/simple-length.js',
       'test/js/computed-style-property-map.js'
   ];
 

--- a/test/js/simple-length.js
+++ b/test/js/simple-length.js
@@ -1,0 +1,28 @@
+suite('SimpleLength', function() {
+  test('SimpleLength is a SimpleLength, LengthValue and StyleValue', function() {
+    var simpleLen = new SimpleLength(3, 'px');
+    assert.instanceOf(simpleLen, SimpleLength, 'A new SimpleLength should be an instance of SimpleLength');
+    assert.instanceOf(simpleLen, LengthValue, 'A new SimpleLength should be an instance of LengthValue');
+    assert.instanceOf(simpleLen, StyleValue, 'A new SimpleLength should be an instance of StyleValue');
+  });
+
+  test('SimpleLength constructor throws exception for invalid types', function() {
+    assert.throws(function() {new SimpleLength(3, 'pxp')});
+    assert.throws(function() {new SimpleLength({})});
+    assert.throws(function() {new SimpleLength({}, 'px')});
+  });
+
+  // Possible constructors: SimpleLength(SimpleLength),
+  // SimpleLength(number, type), SimpleLength(numeric string, type)
+  test('SimpleLength constructor works correctly for numbers and numeric strings', function() {
+    var valueFromString;
+    assert.doesNotThrow(function() {valueFromString = new SimpleLength('9.2', 'px')});
+    assert.strictEqual(valueFromString.type, 'px');
+    assert.strictEqual(valueFromString.value, 9.2);
+
+    var valueFromNumber;
+    assert.doesNotThrow(function() {valueFromNumber = new SimpleLength(10, 'px')});
+    assert.strictEqual(valueFromNumber.type, 'px');
+    assert.strictEqual(valueFromNumber.value, 10);
+  });
+});


### PR DESCRIPTION
Adds dummy functions for API of LengthValue and SimpleLength.
Most functions still unimplemented.  Now added:
- the 'enum' LengthValue.LengthType
  (Note: might want to reconsider how this is done.)
- a constructor for simple-length
- a few tests for simple-length
