### PR TITLE
Add CalcLength

### DIFF
--- a/src/calc-length.js
+++ b/src/calc-length.js
@@ -20,27 +20,26 @@
    */
   function CalcLength(dictionary) {
     if (typeof dictionary != 'object') {
-      throw(new TypeError('CalcLength must be passed a dictionary object'));
+      throw new TypeError('CalcLength must be passed a CalcDictionary object.');
     }
+
+    var hasValidLength = false;
 
     // NOTE: Does not check dictionary for invalid fields.
     for (var type in LengthValue.LengthType) {
       var value = dictionary[type];
       if (typeof value == 'number') {
         this[type] = value;
-      } else if (typeof value == 'string') {
-        var nValue = Number.parseFloat(value);
-        if (!isNaN(nValue)) {
-          this[type] = nValue;
-        } else {
-          throw(new TypeError('Value of each field must be null, a number or a numeric string.'));
-        }
+        hasValidLength = true;
       } else if (value == undefined || value == null) {
         this[type] = null;
       } else {
-        throw(new TypeError('Value of each field must be null, a number or a numeric string.'));
+        throw new TypeError('Value of each length must be null or a number.');
       }
     }
+
+    if (!hasValidLength)
+      throw new TypeError('A CalcDictionary must have at least one valid length.');
   }
 
   CalcLength.prototype = shared.LengthValue.prototype;

--- a/src/calc-length.js
+++ b/src/calc-length.js
@@ -20,29 +20,28 @@
    */
   function CalcLength(dictionary) {
     if (typeof dictionary != 'object') {
-      throw new TypeError('CalcLength must be passed a CalcDictionary object.');
+      throw new TypeError('CalcLength must be passed a dictionary object');
     }
 
-    var hasValidLength = false;
-
-    // NOTE: Does not check dictionary for invalid fields.
+    var isEmpty = true;
     for (var type in LengthValue.LengthType) {
       var value = dictionary[type];
       if (typeof value == 'number') {
         this[type] = value;
-        hasValidLength = true;
+        isEmpty = false;
       } else if (value == undefined || value == null) {
         this[type] = null;
       } else {
-        throw new TypeError('Value of each length must be null or a number.');
+        throw new TypeError('Value of each field must be null, a number or a numeric string.');
       }
     }
 
-    if (!hasValidLength)
+    if (isEmpty) {
       throw new TypeError('A CalcDictionary must have at least one valid length.');
+    }
   }
 
-  CalcLength.prototype = shared.LengthValue.prototype;
+  CalcLength.prototype = Object.create(shared.LengthValue.prototype);
 
   scope.CalcLength = CalcLength;
   if (TYPED_OM_TESTING)

--- a/src/calc-length.js
+++ b/src/calc-length.js
@@ -32,7 +32,7 @@
       } else if (value == undefined || value == null) {
         this[type] = null;
       } else {
-        throw new TypeError('Value of each field must be null, a number or a numeric string.');
+        throw new TypeError('Value of each field must be null or a number.');
       }
     }
 

--- a/src/calc-length.js
+++ b/src/calc-length.js
@@ -1,0 +1,52 @@
+// Copyright 2015 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//     You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//     See the License for the specific language governing permissions and
+// limitations under the License.
+
+(function(shared, scope, testing) {
+
+  /**
+   * CalcLength(dictionary)
+   * TODO: CalcLength(cssString)
+   */
+  function CalcLength(dictionary) {
+    if (typeof dictionary != 'object') {
+      throw(new TypeError('CalcLength must be passed a dictionary object'));
+    }
+
+    // NOTE: Does not check dictionary for invalid fields.
+    for (var type in LengthValue.LengthType) {
+      var value = dictionary[type];
+      if (typeof value == 'number') {
+        this[type] = value;
+      } else if (typeof value == 'string') {
+        var nValue = Number.parseFloat(value);
+        if (!isNaN(nValue)) {
+          this[type] = nValue;
+        } else {
+          throw(new TypeError('Value of each field must be null, a number or a numeric string.'));
+        }
+      } else if (value == undefined || value == null) {
+        this[type] = null;
+      } else {
+        throw(new TypeError('Value of each field must be null, a number or a numeric string.'));
+      }
+    }
+  }
+
+  CalcLength.prototype = shared.LengthValue.prototype;
+
+  scope.CalcLength = CalcLength;
+  if (TYPED_OM_TESTING)
+    testing.CalcLength = CalcLength;
+
+})(baseClasses, window, typedOMTesting);

--- a/src/length-value.js
+++ b/src/length-value.js
@@ -67,41 +67,8 @@
     return new SimpleLength(value, type);
   };
 
-  /**
-   * Creates a LengthValue from a CalcDictionary.
-   * Note if the dictionary contains:
-   *  - 0 valid lengths, an error is thrown
-   *  - 1 valid length, a SimpleLength object is created
-   *  - >1 valid lengths, a CalcLength object is created
-   */
   LengthValue.prototype.fromDictionary = function(dictionary) {
-    if (typeof dictionary != 'object')
-      throw new TypeError('fromDictionary must be passed a CalcDictionary object.');
-
-    var firstValidType = null;
-    var numLengthsFound = 0;
-    for (var type in LengthValue.LengthType) {
-      var value = dictionary[type];
-      if (typeof value == 'number') {
-        numLengthsFound++;
-        if (numLengthsFound > 1) {
-          break; // Found more than one valid length.
-        }
-        // Otherwise, it is the first valid length found.
-        firstValidType = type;
-      } else if (value != null && value != undefined) {
-        throw new TypeError('Value of each length must be null or a number.');
-      }
-    }
-
-    if (numLengthsFound < 1) {
-      throw new TypeError('A CalcDictionary must have at least one valid length.');
-    } else if (numLengthsFound < 2) {
-      return new SimpleLength(dictionary[firstValidType], firstValidType);
-    } else {
-      return new CalcLength(dictionary);
-    }
-
+    return new CalcLength(dictionary);
   };
 
   shared.LengthValue = LengthValue;

--- a/src/length-value.js
+++ b/src/length-value.js
@@ -67,8 +67,37 @@
     return new SimpleLength(value, type);
   };
 
+  /**
+   * Creates a LengthValue from a CalcDictionary.
+   * Note if the dictionary contains:
+   *  - 0 valid lengths, an error is thrown
+   *  - 1 valid length, a SimpleLength object is created
+   *  - >1 valid lengths, a CalcLength object is created
+   */
   LengthValue.prototype.fromDictionary = function(dictionary) {
-    return new CalcLength(dictionary);
+    if (typeof dictionary != 'object')
+      throw new TypeError('fromDictionary must be passed a CalcDictionary object.');
+
+    var firstValidType = null;
+    for (var type in LengthValue.LengthType) {
+      var value = dictionary[type];
+      if (typeof value == 'number') {
+        if (firstValidType) {
+          return new CalcLength(dictionary);
+        } else {
+          firstValidType = type;
+        }
+      } else if (value != null && value != undefined) {
+        throw new TypeError('Value of each length must be null or a number.');
+      }
+    }
+
+    if (firstValidType != null) {
+      return new SimpleLength(dictionary[firstValidType], firstValidType);
+    } else {
+      throw new TypeError('A CalcDictionary must have at least one valid length.');
+    }
+
   };
 
   shared.LengthValue = LengthValue;

--- a/src/length-value.js
+++ b/src/length-value.js
@@ -20,7 +20,6 @@
   /**
    * The different possible length types.
    * NOTE: Must use uppercase as 'in' is a reserved word.
-   * @enum {string}
    */
   LengthValue.LengthType = {
     PX: 'px',
@@ -65,11 +64,11 @@
   };
 
   LengthValue.prototype.fromValue = function(value, type) {
-    throw new TypeError('Not implemented yet');
+    return new SimpleLength(value, type);
   };
 
   LengthValue.prototype.fromDictionary = function(dictionary) {
-    throw new TypeError('Not implemented yet');
+    return new CalcLength(dictionary);
   };
 
   shared.LengthValue = LengthValue;

--- a/src/length-value.js
+++ b/src/length-value.js
@@ -79,23 +79,27 @@
       throw new TypeError('fromDictionary must be passed a CalcDictionary object.');
 
     var firstValidType = null;
+    var numLengthsFound = 0;
     for (var type in LengthValue.LengthType) {
       var value = dictionary[type];
       if (typeof value == 'number') {
-        if (firstValidType) {
-          return new CalcLength(dictionary);
-        } else {
-          firstValidType = type;
+        numLengthsFound++;
+        if (numLengthsFound > 1) {
+          break; // Found more than one valid length.
         }
+        // Otherwise, it is the first valid length found.
+        firstValidType = type;
       } else if (value != null && value != undefined) {
         throw new TypeError('Value of each length must be null or a number.');
       }
     }
 
-    if (firstValidType != null) {
+    if (numLengthsFound < 1) {
+      throw new TypeError('A CalcDictionary must have at least one valid length.');
+    } else if (numLengthsFound < 2) {
       return new SimpleLength(dictionary[firstValidType], firstValidType);
     } else {
-      throw new TypeError('A CalcDictionary must have at least one valid length.');
+      return new CalcLength(dictionary);
     }
 
   };

--- a/src/simple-length.js
+++ b/src/simple-length.js
@@ -17,8 +17,6 @@
   /**
    * SimpleLength(value, type)
    * TODO: SimpleLength(simpleLength), SimpleLength(cssString)
-   *
-   * @constructor
    */
   function SimpleLength(value, type) {
     if (arguments.length == 2 && typeof type == 'string' &&

--- a/target-config.js
+++ b/target-config.js
@@ -23,13 +23,16 @@
       'src/number-value.js',
       'src/length-value.js',
       'src/simple-length.js',
+      'src/calc-length.js',
       'src/style-property-map.js',
       'src/computed-style-property-map.js'
   ];
 
   var typedOMTest = [
       'test/js/number-value.js',
+      'test/js/length-value.js',
       'test/js/simple-length.js',
+      'test/js/calc-length.js',
       'test/js/computed-style-property-map.js'
   ];
 

--- a/test/js/calc-length.js
+++ b/test/js/calc-length.js
@@ -1,7 +1,7 @@
 suite('CalcLength', function() {
   test('CalcLength is a CalcLength, LengthValue and StyleValue', function() {
-    var calcLen = new CalcLength({});
-    assert.instanceOf(calcLen, CalcLength, 'A new CalcLength should be an instance of SimpleLength');
+    var calcLen = new CalcLength({PX: 10});
+    assert.instanceOf(calcLen, CalcLength, 'A new CalcLength should be an instance of CalcLength');
     assert.instanceOf(calcLen, LengthValue, 'A new CalcLength should be an instance of LengthValue');
     assert.instanceOf(calcLen, StyleValue, 'A new CalcLength should be an instance of StyleValue');
   });
@@ -9,28 +9,27 @@ suite('CalcLength', function() {
   test('CalcLength constructor throws exception for invalid types', function() {
     assert.throws(function() {new CalcLength({PX: 'abc'})});
     assert.throws(function() {new CalcLength({PX: {}})});
+    assert.throws(function() {new CalcLength({})});
   });
 
-  test('CalcLength empty constructor initializes other fields to null', function() {
-    var lenFromEmptyDict;
-    assert.doesNotThrow(function() {lenFromEmptyDict = new CalcLength({})});
-    for (var type in LengthValue.LengthType)
-      assert.isNull(lenFromEmptyDict[type], 'Each field in an empty instantiated CalcLength is null');
+  test('CalcLength constructor initializes other fields to null', function() {
+    var singleValDict;
+    assert.doesNotThrow(function() {singleValDict = new CalcLength({PX: 10})});
+    for (var type in LengthValue.LengthType) {
+      if (type != 'PX')
+        assert.isNull(singleValDict[type], 'Each undeclared field in CalcLength is null');
+    }
   });
 
   // Possible constructor: CalcLength(dictionary)
   test('CalcLength constructor works correctly for numbers and numeric strings', function() {
-    var valueFromString;
-    assert.doesNotThrow(function() {valueFromString = new CalcLength({PX: '9.2'})});
-    assert.strictEqual(valueFromString.PX, 9.2);
+    var singleValue;
+    assert.doesNotThrow(function() {singleValue = new CalcLength({PX: 10})});
+    assert.strictEqual(singleValue.PX, 10);
 
-    var valueFromNumber;
-    assert.doesNotThrow(function() {valueFromNumber = new CalcLength({PX: 10})});
-    assert.strictEqual(valueFromNumber.PX, 10);
-
-    var valueFromMixed;
-    assert.doesNotThrow(function() {valueFromMixed = new CalcLength({PX: 10, EM: '3.2'})});
-    assert.strictEqual(valueFromMixed.PX, 10);
-    assert.strictEqual(valueFromMixed.EM, 3.2);
+    var multiValue;
+    assert.doesNotThrow(function() {multiValue = new CalcLength({PX: 10, EM: 3.2})});
+    assert.strictEqual(multiValue.PX, 10);
+    assert.strictEqual(multiValue.EM, 3.2);
   });
 });

--- a/test/js/calc-length.js
+++ b/test/js/calc-length.js
@@ -1,0 +1,36 @@
+suite('CalcLength', function() {
+  test('CalcLength is a CalcLength, LengthValue and StyleValue', function() {
+    var calcLen = new CalcLength({});
+    assert.instanceOf(calcLen, CalcLength, 'A new CalcLength should be an instance of SimpleLength');
+    assert.instanceOf(calcLen, LengthValue, 'A new CalcLength should be an instance of LengthValue');
+    assert.instanceOf(calcLen, StyleValue, 'A new CalcLength should be an instance of StyleValue');
+  });
+
+  test('CalcLength constructor throws exception for invalid types', function() {
+    assert.throws(function() {new CalcLength({PX: 'abc'})});
+    assert.throws(function() {new CalcLength({PX: {}})});
+  });
+
+  test('CalcLength empty constructor initializes other fields to null', function() {
+    var lenFromEmptyDict;
+    assert.doesNotThrow(function() {lenFromEmptyDict = new CalcLength({})});
+    for (var type in LengthValue.LengthType)
+      assert.isNull(lenFromEmptyDict[type], 'Each field in an empty instantiated CalcLength is null');
+  });
+
+  // Possible constructor: CalcLength(dictionary)
+  test('CalcLength constructor works correctly for numbers and numeric strings', function() {
+    var valueFromString;
+    assert.doesNotThrow(function() {valueFromString = new CalcLength({PX: '9.2'})});
+    assert.strictEqual(valueFromString.PX, 9.2);
+
+    var valueFromNumber;
+    assert.doesNotThrow(function() {valueFromNumber = new CalcLength({PX: 10})});
+    assert.strictEqual(valueFromNumber.PX, 10);
+
+    var valueFromMixed;
+    assert.doesNotThrow(function() {valueFromMixed = new CalcLength({PX: 10, EM: '3.2'})});
+    assert.strictEqual(valueFromMixed.PX, 10);
+    assert.strictEqual(valueFromMixed.EM, 3.2);
+  });
+});

--- a/test/js/calc-length.js
+++ b/test/js/calc-length.js
@@ -12,20 +12,21 @@ suite('CalcLength', function() {
     assert.throws(function() {new CalcLength({})});
   });
 
-  test('CalcLength constructor initializes other fields to null', function() {
-    var singleValDict;
-    assert.doesNotThrow(function() {singleValDict = new CalcLength({PX: 10})});
+  test('CalcLength empty constructor initializes other fields to null', function() {
+    var lenFromEmptyDict;
+    assert.doesNotThrow(function() {lenFromEmptyDict = new CalcLength({PX: 10})});
     for (var type in LengthValue.LengthType) {
-      if (type != 'PX')
-        assert.isNull(singleValDict[type], 'Each undeclared field in CalcLength is null');
+      if (type != 'PX') {
+        assert.isNull(lenFromEmptyDict[type], 'Each field in an empty instantiated CalcLength is null');
+      }
     }
   });
 
   // Possible constructor: CalcLength(dictionary)
   test('CalcLength constructor works correctly for numbers and numeric strings', function() {
-    var singleValue;
-    assert.doesNotThrow(function() {singleValue = new CalcLength({PX: 10})});
-    assert.strictEqual(singleValue.PX, 10);
+    var valueFromNumber;
+    assert.doesNotThrow(function() {valueFromNumber = new CalcLength({PX: 10})});
+    assert.strictEqual(valueFromNumber.PX, 10);
 
     var multiValue;
     assert.doesNotThrow(function() {multiValue = new CalcLength({PX: 10, EM: 3.2})});

--- a/test/js/length-value.js
+++ b/test/js/length-value.js
@@ -1,13 +1,28 @@
 suite('LengthValue', function() {
-  test('fromValue returns instanceof a LengthValue and StyleValue', function() {
+  test('fromValue returns instanceof a SimpleLength, LengthValue and StyleValue', function() {
     var fromVal = (new LengthValue()).fromValue(9.2, 'px');
-    assert.instanceOf(fromVal, LengthValue, 'A new LengthValue should be an instance of LengthValue');
-    assert.instanceOf(fromVal, StyleValue, 'A new LengthValue should be an instance of StyleValue');
+    assert.instanceOf(fromVal, SimpleLength, 'A new fromValue should be an instance of SimpleLength');
+    assert.instanceOf(fromVal, LengthValue, 'A new fromValue should be an instance of LengthValue');
+    assert.instanceOf(fromVal, StyleValue, 'A new fromValue should be an instance of StyleValue');
   });
 
-  test('fromDictionary returns instanceof a LengthValue and StyleValue', function() {
-    var fromDict = (new LengthValue()).fromDictionary({});
-    assert.instanceOf(fromDict, LengthValue, 'A new LengthValue should be an instance of LengthValue');
-    assert.instanceOf(fromDict, StyleValue, 'A new LengthValue should be an instance of StyleValue');
+  test('fromDictionary with single length returns instanceof a SimpleLength, LengthValue and StyleValue', function() {
+    var fromDict = (new LengthValue()).fromDictionary({PX: 10});
+    assert.instanceOf(fromDict, SimpleLength, 'A new fromDictionary with a single length should be an instance of SimpleLength');
+    assert.instanceOf(fromDict, LengthValue, 'A new fromDictionary should be an instance of LengthValue');
+    assert.instanceOf(fromDict, StyleValue, 'A new fromDictionary should be an instance of StyleValue');
+  });
+
+  test('fromDictionary with multiple lengths returns instanceof a CalcLength, LengthValue and StyleValue', function() {
+    var fromDict = (new LengthValue()).fromDictionary({PX: 10, EM: 10});
+    assert.instanceOf(fromDict, CalcLength, 'A new fromDictionary with a multiple lengths should be an instance of CalcLength');
+    assert.instanceOf(fromDict, LengthValue, 'A new fromDictionary should be an instance of LengthValue');
+    assert.instanceOf(fromDict, StyleValue, 'A new fromDictionary should be an instance of StyleValue');
+  });
+
+  test('fromDictionary throws exception for invalid types', function() {
+    assert.throws(function() {(new LengthValue()).fromDictionary({})});
+    assert.throws(function() {(new LengthValue()).fromDictionary({BLAH: 10})});
+    assert.throws(function() {(new LengthValue()).fromDictionary({PX: '10'})});
   });
 });

--- a/test/js/length-value.js
+++ b/test/js/length-value.js
@@ -1,0 +1,13 @@
+suite('LengthValue', function() {
+  test('fromValue returns instanceof a LengthValue and StyleValue', function() {
+    var fromVal = (new LengthValue()).fromValue(9.2, 'px');
+    assert.instanceOf(fromVal, LengthValue, 'A new LengthValue should be an instance of LengthValue');
+    assert.instanceOf(fromVal, StyleValue, 'A new LengthValue should be an instance of StyleValue');
+  });
+
+  test('fromDictionary returns instanceof a LengthValue and StyleValue', function() {
+    var fromDict = (new LengthValue()).fromDictionary({});
+    assert.instanceOf(fromDict, LengthValue, 'A new LengthValue should be an instance of LengthValue');
+    assert.instanceOf(fromDict, StyleValue, 'A new LengthValue should be an instance of StyleValue');
+  });
+});

--- a/test/js/length-value.js
+++ b/test/js/length-value.js
@@ -1,28 +1,16 @@
 suite('LengthValue', function() {
-  test('fromValue returns instanceof a SimpleLength, LengthValue and StyleValue', function() {
+  test('fromValue returns instanceof a LengthValue and StyleValue', function() {
     var fromVal = (new LengthValue()).fromValue(9.2, 'px');
     assert.instanceOf(fromVal, SimpleLength, 'A new fromValue should be an instance of SimpleLength');
     assert.instanceOf(fromVal, LengthValue, 'A new fromValue should be an instance of LengthValue');
     assert.instanceOf(fromVal, StyleValue, 'A new fromValue should be an instance of StyleValue');
   });
 
-  test('fromDictionary with single length returns instanceof a SimpleLength, LengthValue and StyleValue', function() {
+  test('fromDictionary returns instanceof a LengthValue and StyleValue', function() {
     var fromDict = (new LengthValue()).fromDictionary({PX: 10});
-    assert.instanceOf(fromDict, SimpleLength, 'A new fromDictionary with a single length should be an instance of SimpleLength');
+    assert.instanceOf(fromDict, CalcLength, 'A new fromDictionary should be an instance of CalcLength');
+  });
     assert.instanceOf(fromDict, LengthValue, 'A new fromDictionary should be an instance of LengthValue');
     assert.instanceOf(fromDict, StyleValue, 'A new fromDictionary should be an instance of StyleValue');
-  });
-
-  test('fromDictionary with multiple lengths returns instanceof a CalcLength, LengthValue and StyleValue', function() {
-    var fromDict = (new LengthValue()).fromDictionary({PX: 10, EM: 10});
-    assert.instanceOf(fromDict, CalcLength, 'A new fromDictionary with a multiple lengths should be an instance of CalcLength');
-    assert.instanceOf(fromDict, LengthValue, 'A new fromDictionary should be an instance of LengthValue');
-    assert.instanceOf(fromDict, StyleValue, 'A new fromDictionary should be an instance of StyleValue');
-  });
-
-  test('fromDictionary throws exception for invalid types', function() {
-    assert.throws(function() {(new LengthValue()).fromDictionary({})});
-    assert.throws(function() {(new LengthValue()).fromDictionary({BLAH: 10})});
-    assert.throws(function() {(new LengthValue()).fromDictionary({PX: '10'})});
   });
 });


### PR DESCRIPTION
Adds:
- CalcLength constructor
- A couple of tests for CalcLength
- fromValue / fromDictionary in LengthValue calls
  corresponding constructors for SimpleLength / CalcLength
- extremely simple tests for fromValue / fromDictionary
- remove unnecessary tags for consistency
  (@constructor, @enum tags)
