### PR TITLE
Add cssString attribute to SimpleLength

### DIFF
--- a/src/length-value.js
+++ b/src/length-value.js
@@ -24,7 +24,7 @@
    */
   LengthValue.LengthType = {
     PX: 'px',
-    PERCENT: 'percent',
+    PERCENT: '%',
     EM: 'em',
     EX: 'ex',
     CH: 'ch',

--- a/src/simple-length.js
+++ b/src/simple-length.js
@@ -23,7 +23,7 @@
   function SimpleLength(value, type) {
     if (arguments.length == 2 && typeof type == 'string' &&
       type.toUpperCase() in LengthValue.LengthType) {
-      this.type = LengthValue.LengthType[type.toUpperCase()];
+      this.type = type.toUpperCase();
       if (typeof value == 'number') {
         this.value = value;
       } else if (typeof value == 'string') {
@@ -34,11 +34,13 @@
       }
     }
     if (this.value == undefined) {
-      throw(new TypeError('Value of SimpleLength must be a number or a numeric string.'));
+      throw new TypeError('Value of SimpleLength must be a number or a numeric string.');
     }
+
+    this.cssString = this.value + LengthValue.LengthType[this.type];
   }
 
-  SimpleLength.prototype = shared.LengthValue.prototype;
+  SimpleLength.prototype = Object.create(shared.LengthValue.prototype);
 
   scope.SimpleLength = SimpleLength;
   if (TYPED_OM_TESTING)

--- a/test/js/simple-length.js
+++ b/test/js/simple-length.js
@@ -17,12 +17,26 @@ suite('SimpleLength', function() {
   test('SimpleLength constructor works correctly for numbers and numeric strings', function() {
     var valueFromString;
     assert.doesNotThrow(function() {valueFromString = new SimpleLength('9.2', 'px')});
-    assert.strictEqual(valueFromString.type, 'px');
+    assert.strictEqual(valueFromString.type, 'PX');
     assert.strictEqual(valueFromString.value, 9.2);
 
     var valueFromNumber;
     assert.doesNotThrow(function() {valueFromNumber = new SimpleLength(10, 'px')});
-    assert.strictEqual(valueFromNumber.type, 'px');
+    assert.strictEqual(valueFromNumber.type, 'PX');
     assert.strictEqual(valueFromNumber.value, 10);
+  });
+
+  test('SimpleLength cssStrings correctly generated', function() {
+    var valueFromString;
+    assert.doesNotThrow(function() {valueFromString = new SimpleLength('9.2', 'px')});
+    assert.strictEqual(valueFromString.cssString, '9.2px');
+
+    var valueFromNumber;
+    assert.doesNotThrow(function() {valueFromNumber = new SimpleLength(10, 'px')});
+    assert.strictEqual(valueFromNumber.cssString, '10px');
+
+    var percentValue;
+    assert.doesNotThrow(function() {percentValue = new SimpleLength(50, 'percent')});
+    assert.strictEqual(percentValue.cssString, '50%');
   });
 });


### PR DESCRIPTION
- Adds the cssString attribute to SimpleLength.
- Changed string value of percent in enum, such that
  SimpleLength(10, 'percent').cssString is '10%'
- Add some tests
