### PR TITLE
Add CalcLength.cssString

### DIFF
--- a/src/calc-length.js
+++ b/src/calc-length.js
@@ -23,12 +23,20 @@
       throw new TypeError('CalcLength must be passed a dictionary object');
     }
 
+    this.cssString = 'calc(';
     var isEmpty = true;
+
     for (var index in shared.LengthValue.LengthType) {
       var type = shared.LengthValue.LengthType[index];
       var value = dictionary[type];
       if (typeof value == 'number') {
         this[type] = value;
+        // Add a "+" in the cssString if needed
+        // (i.e before non-negative numbers, not including the first number)
+        if (!isEmpty && value >= 0) {
+          this.cssString += '+';
+        }
+        this.cssString += value + shared.LengthValue.cssStringTypeRepresentation(type);
         isEmpty = false;
       } else if (value == undefined || value == null) {
         this[type] = null;
@@ -36,6 +44,8 @@
         throw new TypeError('Value of each field must be null or a number.');
       }
     }
+
+    this.cssString += ")";
 
     if (isEmpty) {
       throw new TypeError('A CalcDictionary must have at least one valid length.');

--- a/src/calc-length.js
+++ b/src/calc-length.js
@@ -23,20 +23,12 @@
       throw new TypeError('CalcLength must be passed a dictionary object');
     }
 
-    this.cssString = 'calc(';
     var isEmpty = true;
-
     for (var index in shared.LengthValue.LengthType) {
       var type = shared.LengthValue.LengthType[index];
       var value = dictionary[type];
       if (typeof value == 'number') {
         this[type] = value;
-        // Add a "+" in the cssString if needed
-        // (i.e before non-negative numbers, not including the first number)
-        if (!isEmpty && value >= 0) {
-          this.cssString += '+';
-        }
-        this.cssString += value + shared.LengthValue.cssStringTypeRepresentation(type);
         isEmpty = false;
       } else if (value == undefined || value == null) {
         this[type] = null;
@@ -45,11 +37,29 @@
       }
     }
 
-    this.cssString += ")";
-
     if (isEmpty) {
       throw new TypeError('A CalcDictionary must have at least one valid length.');
     }
+
+    function createCssString(calcLen) {
+      calcLen.cssString = 'calc(';
+      var isFirst = true;
+      for (var index in shared.LengthValue.LengthType) {
+        var type = shared.LengthValue.LengthType[index];
+        var value = calcLen[type];
+        if (value != null) {
+          // Add a "+" in the cssString if needed
+          // (i.e before non-negative numbers, not including the first number)
+          if (!isFirst && value >= 0) {
+            calcLen.cssString += '+';
+          }
+          calcLen.cssString += value + shared.LengthValue.cssStringTypeRepresentation(type);
+          isFirst = false;
+        }
+      }
+      calcLen.cssString += ")";
+    }
+    createCssString(this);
   }
 
   CalcLength.prototype = Object.create(shared.LengthValue.prototype);

--- a/src/length-value.js
+++ b/src/length-value.js
@@ -24,6 +24,19 @@
     'cm', 'mm', 'q', 'in', 'pc', 'pt'
   ];
 
+  LengthValue.cssStringTypeRepresentation = function(type) {
+    if (LengthValue.LengthType.indexOf(type) < 0) {
+      throw new TypeError('Invalid LengthType.');
+    }
+
+    switch (type) {
+      case 'percent':
+        return '%';
+      default:
+        return type;
+    }
+  }
+
   LengthValue.prototype = Object.create(shared.StyleValue.prototype);
 
   // Length Calculation Methods

--- a/test/js/calc-length.js
+++ b/test/js/calc-length.js
@@ -24,7 +24,7 @@ suite('CalcLength', function() {
   });
 
   // Possible constructor: CalcLength(dictionary)
-  test('CalcLength constructor works correctly for numbers and numeric strings', function() {
+  test('CalcLength constructor works correctly for single and multi value CalcDictionaries', function() {
     var valueFromNumber;
     assert.doesNotThrow(function() {valueFromNumber = new CalcLength({px: 10})});
     assert.strictEqual(valueFromNumber.px, 10);
@@ -33,5 +33,30 @@ suite('CalcLength', function() {
     assert.doesNotThrow(function() {multiValue = new CalcLength({px: 10, em: 3.2})});
     assert.strictEqual(multiValue.px, 10);
     assert.strictEqual(multiValue.em, 3.2);
+  });
+
+  test('CalcLength cssString is correct for single and multi value strings', function() {
+    var valueFromNumber;
+    assert.doesNotThrow(function() {valueFromNumber = new CalcLength({px: 10})});
+    assert.strictEqual(valueFromNumber.px, 10);
+    assert.strictEqual(valueFromNumber.cssString, 'calc(10px)');
+
+    var multiValue;
+    assert.doesNotThrow(function() {multiValue = new CalcLength({px: 10, em: 3.2})});
+    assert.strictEqual(multiValue.px, 10);
+    assert.strictEqual(multiValue.em, 3.2);
+    assert.strictEqual(multiValue.cssString, 'calc(10px+3.2em)');
+
+    var negativeValues;
+    assert.doesNotThrow(function() {negativeValues = new CalcLength({px: -10, em: -3.2, pt:0})});
+    assert.strictEqual(negativeValues.px, -10);
+    assert.strictEqual(negativeValues.em, -3.2);
+    assert.strictEqual(negativeValues.pt, 0);
+    assert.strictEqual(negativeValues.cssString, 'calc(-10px-3.2em+0pt)');
+
+    var percentValue;
+    assert.doesNotThrow(function() {valueFromNumber = new CalcLength({percent: 10})});
+    assert.strictEqual(valueFromNumber.percent, 10);
+    assert.strictEqual(valueFromNumber.cssString, 'calc(10%)');
   });
 });

--- a/test/js/calc-length.js
+++ b/test/js/calc-length.js
@@ -36,10 +36,10 @@ suite('CalcLength', function() {
   });
 
   test('CalcLength cssString is correct for single and multi value strings', function() {
-    var valueFromNumber;
-    assert.doesNotThrow(function() {valueFromNumber = new CalcLength({px: 10})});
-    assert.strictEqual(valueFromNumber.px, 10);
-    assert.strictEqual(valueFromNumber.cssString, 'calc(10px)');
+    var singleValue;
+    assert.doesNotThrow(function() {singleValue = new CalcLength({px: 10})});
+    assert.strictEqual(singleValue.px, 10);
+    assert.strictEqual(singleValue.cssString, 'calc(10px)');
 
     var multiValue;
     assert.doesNotThrow(function() {multiValue = new CalcLength({px: 10, em: 3.2})});
@@ -55,8 +55,8 @@ suite('CalcLength', function() {
     assert.strictEqual(negativeValues.cssString, 'calc(-10px-3.2em+0pt)');
 
     var percentValue;
-    assert.doesNotThrow(function() {valueFromNumber = new CalcLength({percent: 10})});
-    assert.strictEqual(valueFromNumber.percent, 10);
-    assert.strictEqual(valueFromNumber.cssString, 'calc(10%)');
+    assert.doesNotThrow(function() {percentValue = new CalcLength({percent: 10})});
+    assert.strictEqual(percentValue.percent, 10);
+    assert.strictEqual(percentValue.cssString, 'calc(10%)');
   });
 });


### PR DESCRIPTION
- Creates the cssString attribute for calcLength
  in the constructor.
- Create a function in LengthValue to return the cssString
  representation of each LengthValue.LengthType
  [Note: uses switch/case block for extensibility](LengthValue.cssStringTypeRepresentation)
- Add appropriate cssString test cases
  (single, negative, multi, percent)
