### PR TITLE
Add SimpleLength.cssString

### DIFF
--- a/src/calc-length.js
+++ b/src/calc-length.js
@@ -41,23 +41,23 @@
       throw new TypeError('A CalcDictionary must have at least one valid length.');
     }
 
-    function createCssString(calcLen) {
-      calcLen.cssString = 'calc(';
+    function createCssString(calcLength) {
+      calcLength.cssString = 'calc(';
       var isFirst = true;
       for (var index in shared.LengthValue.LengthType) {
         var type = shared.LengthValue.LengthType[index];
-        var value = calcLen[type];
+        var value = calcLength[type];
         if (value != null) {
           // Add a "+" in the cssString if needed
           // (i.e before non-negative numbers, not including the first number)
           if (!isFirst && value >= 0) {
-            calcLen.cssString += '+';
+            calcLength.cssString += '+';
           }
-          calcLen.cssString += value + shared.LengthValue.cssStringTypeRepresentation(type);
+          calcLength.cssString += value + shared.LengthValue.cssStringTypeRepresentation(type);
           isFirst = false;
         }
       }
-      calcLen.cssString += ")";
+      calcLength.cssString += ')';
     }
     createCssString(this);
   }

--- a/src/simple-length.js
+++ b/src/simple-length.js
@@ -33,6 +33,8 @@
     if (this.value == undefined) {
       throw new TypeError('Value of SimpleLength must be a number or a numeric string.');
     }
+
+    this.cssString = this.value + shared.LengthValue.cssStringTypeRepresentation(this.type);
   }
 
   SimpleLength.prototype = Object.create(shared.LengthValue.prototype);

--- a/test/js/simple-length.js
+++ b/test/js/simple-length.js
@@ -25,4 +25,22 @@ suite('SimpleLength', function() {
     assert.strictEqual(valueFromNumber.type, 'px');
     assert.strictEqual(valueFromNumber.value, 10);
   });
+
+  test('SimpleLength cssString is correctly defined for different values and types', function() {
+    var valueFromString;
+    assert.doesNotThrow(function() {valueFromString = new SimpleLength('9.2', 'px')});
+    assert.strictEqual(valueFromString.cssString, '9.2px');
+
+    var valueFromNumber;
+    assert.doesNotThrow(function() {valueFromNumber = new SimpleLength(10, 'px')});
+    assert.strictEqual(valueFromNumber.cssString, '10px');
+
+    var percentValue;
+    assert.doesNotThrow(function() {percentValue = new SimpleLength(10, 'percent')});
+    assert.strictEqual(percentValue.cssString, '10%');
+
+    var negativeValue;
+    assert.doesNotThrow(function() {negativeValue = new SimpleLength(-3.2, 'px')});
+    assert.strictEqual(negativeValue.cssString, '-3.2px');
+  });
 });


### PR DESCRIPTION
- Adds SimpleLength.cssString
- Adds test cases for cssString, including:
  number, numeric string and negative values and percent type
- Code Style (naming): Do not use abbreviations as var names
  (Updated naming in createCssString function in CalcLength)
