### PR TITLE
Add keyword and length properties to map

### DIFF
--- a/src/computed-style-property-map.js
+++ b/src/computed-style-property-map.js
@@ -37,9 +37,9 @@
     if (!value) {
       return null;
     }
-    if (value == 'inherit') {
-      // TODO: Other keywords
-      throw new TypeError('Not implemented yet');
+
+    if (scope.KeywordValue.isKeywordValue(value)) {
+      return new scope.KeywordValue(value);
     }
 
     // TODO: The rest of the properties once the rest of the StyleValues are defined.
@@ -53,6 +53,29 @@
       case 'widows':
       case 'z-index':
         return new scope.NumberValue(value);
+
+      // These properties take only a length value (length and percentage),
+      // or a keyword handled above.
+      case 'bottom':
+      case 'height':
+      case 'left':
+      case 'max-height':
+      case 'max-width':
+      case 'min-height':
+      case 'min-width':
+      case 'right':
+      case 'text-indent':
+      case 'top':
+      case 'width':
+        // TODO: support it being any length value.
+        return new scope.SimpleLength(value);
+
+      // These properties only take a length value, but do not take percentage.
+      case 'letter-spacing':
+      case 'word-spacing':
+        throw new TypeError('Not implemented yet');
+
+      // These properties take a number or SimpleLength
 
       case 'line-height':
         // normal | <number> | <length> | <percentage> | inherit
@@ -78,15 +101,28 @@
 
     switch (property) {
       // These properties always return a single value.
+      case 'bottom':
+      case 'height':
+      case 'left':
+      case 'letter-spacing':
       case 'line-height':
+      case 'max-height':
+      case 'max-width':
+      case 'min-height':
+      case 'min-width':
       case 'opacity':
       case 'orphans':
       case 'pitch-range':
       case 'richness':
+      case 'right':
       case 'speech-rate':
       case 'stress':
+      case 'text-indent':
+      case 'top':
       case 'volume':
       case 'widows':
+      case 'width':
+      case 'word-spacing':
       case 'z-index':
         var value = this.get(property)
         return value ? [value] : [];

--- a/src/keyword-value.js
+++ b/src/keyword-value.js
@@ -22,7 +22,7 @@
     this.cssString = value;
   }
 
-  KeywordValue.StyleValueKeyword = ['initial', 'inherit', 'revert', 'unset'];
+  KeywordValue.StyleValueKeyword = ['auto', 'initial', 'inherit', 'revert', 'unset'];
 
   KeywordValue.isKeywordValue = function(cssString) {
     return KeywordValue.StyleValueKeyword.indexOf(cssString) >= 0;

--- a/test/js/computed-style-property-map.js
+++ b/test/js/computed-style-property-map.js
@@ -34,15 +34,14 @@ suite('ComputedStylePropertyMap', function() {
     assert.equal(opacity.cssString, '0.5');
   });
 
-  // NOTE: window.getComputedStyle(element)[property] in
-  // ComputedStylePropertyMap.get is the resolved style,
-  // so tests need to be written accordingly.
-  test.skip('ComputedStylePropertyMap.get works for KeywordValues', function() {
+  test('ComputedStylePropertyMap.get works for KeywordValues', function() {
     var computedStyleMap = new ComputedStylePropertyMap(this.element);
     var right = computedStyleMap.get('right');
     assert.instanceOf(right, KeywordValue);
     assert.instanceOf(right, StyleValue);
-    // TODO: check what inherit resolves to.
+    // 'inherit' resolves to 'auto' in this case.
+    assert.equal(right.keywordValue, 'auto');
+    assert.equal(right.cssString, 'auto');
   });
 
   test.skip('ComputedStylePropertyMap.get works for properties that can only be LengthValues', function() {

--- a/test/js/computed-style-property-map.js
+++ b/test/js/computed-style-property-map.js
@@ -3,6 +3,9 @@ suite('ComputedStylePropertyMap', function() {
     this.element = document.createElement('div');
     document.documentElement.appendChild(this.element);
     this.element.style.opacity = '0.5';
+    this.element.style.height = '100px';
+    this.element.style.width = 'calc(50px+10em)';
+    this.element.style.right = 'inherit';
   });
   teardown(function() {
     document.documentElement.removeChild(this.element);
@@ -29,5 +32,36 @@ suite('ComputedStylePropertyMap', function() {
     assert.instanceOf(opacity, NumberValue);
     assert.equal(opacity.value, 0.5);
     assert.equal(opacity.cssString, '0.5');
+  });
+
+  // NOTE: window.getComputedStyle(element)[property] in
+  // ComputedStylePropertyMap.get is the resolved style,
+  // so tests need to be written accordingly.
+  test.skip('ComputedStylePropertyMap.get works for KeywordValues', function() {
+    var computedStyleMap = new ComputedStylePropertyMap(this.element);
+    var right = computedStyleMap.get('right');
+    assert.instanceOf(right, KeywordValue);
+    assert.instanceOf(right, StyleValue);
+    // TODO: check what inherit resolves to.
+  });
+
+  test.skip('ComputedStylePropertyMap.get works for properties that can only be LengthValues', function() {
+    var computedStyleMap = new ComputedStylePropertyMap(this.element);
+    var height = computedStyleMap.get('height');
+    assert.instanceOf(height, LengthValue);
+    assert.instanceOf(height, SimpleLength);
+    assert.equal(height.value, 100);
+    assert.equal(height.type, 'px');
+    assert.equal(height.cssString, '100px');
+  });
+
+  test.skip('ComputedStylePropertyMap.get works for properties with CalcLengths', function() {
+    var computedStyleMap = new ComputedStylePropertyMap(this.element);
+    var width = computedStyleMap.get('width');
+    assert.instanceOf(width, LengthValue);
+    assert.instanceOf(width, CalcLength);
+    assert.equal(width.px, 50);
+    assert.equal(width.em, 10);
+    assert.equal(width.cssString, 'calc(50px+10em)');
   });
 });

--- a/test/js/keyword-value.js
+++ b/test/js/keyword-value.js
@@ -15,6 +15,7 @@ suite('KeywordValue', function() {
   });
 
   test('KeywordValue.isKeywordValue is true for valid values', function() {
+    assert.isTrue(KeywordValue.isKeywordValue('auto'));
     assert.isTrue(KeywordValue.isKeywordValue('initial'));
     assert.isTrue(KeywordValue.isKeywordValue('inherit'));
     assert.isTrue(KeywordValue.isKeywordValue('revert'));


### PR DESCRIPTION
- adds a list of properties that take length values
  to ComputedStylePropertyMap
- adds a check for keywords
  NOTE: this may have to change / move around
- adds some basic tests for length and keyword values
  for the map
  NOTE: These tests are currently being skipped as parsing is
  unimplemented.
- adds `auto` to KeywordValue
  NOTE: this implementation is subject to change
