### PR TITLE
Code style changes in base classes

### DIFF
--- a/src/style-property-map.js
+++ b/src/style-property-map.js
@@ -16,19 +16,18 @@
 
 function StylePropertyMap() {}
 
-	// Nick and Nat: You will need to decide which of these methods you want to implement.
-	StylePropertyMap.prototype = {
-	  append: function(property, value) {},
-	  delete: function(property) {},
-	  get: function(property) {},
-	  getAll: function(property) {},
-	  has: function(property) {},
-	  set: function(property, value) {},
-	  getProperties: function() {}
-	}
+  StylePropertyMap.prototype = {
+    append: function(property, value) {},
+    delete: function(property) {},
+    get: function(property) {},
+    getAll: function(property) {},
+    has: function(property) {},
+    set: function(property, value) {},
+    getProperties: function() {}
+  }
 
-	shared.StylePropertyMap = StylePropertyMap;
-	if (TYPED_OM_TESTING)
-		testing.StylePropertyMap = StylePropertyMap;
+  shared.StylePropertyMap = StylePropertyMap;
+  if (TYPED_OM_TESTING)
+    testing.StylePropertyMap = StylePropertyMap;
 
 })(baseClasses, window, typedOMTesting)

--- a/src/style-value.js
+++ b/src/style-value.js
@@ -17,18 +17,15 @@
   function StyleValue() {
   }
 
-  StyleValue.prototype = {
-    // Nick and Nat: Do NOT worry about fleshing this out as you add StyleValue types. We can add
-    // more parsing logic when we start working on StylePropertyMap.
-    parse: function(property, value) {
-      if (typeof value == 'string') {
-        nValue = Number.parseFloat(value);
-        if (nValue !== NaN) {
-          return new NumberValue(nValue);
-        }
+  // TODO: Include parsing logic here.
+  StyleValue.parse = function(property, value) {
+    if (typeof value == 'string') {
+      numberValue = Number.parseFloat(value);
+      if (numberValue !== NaN) {
+        return new NumberValue(numberValue);
       }
-      return null;
     }
+    return null;
   }
 
   shared.StyleValue = StyleValue;


### PR DESCRIPTION
- convert tabs to spaces for consistency
- StyleValue.parse is a static method,
  so should not be in the prototype.
