### PR TITLE
Computed map properties

### DIFF
--- a/src/computed-style-property-map.js
+++ b/src/computed-style-property-map.js
@@ -38,9 +38,9 @@
     if (!value) {
       return null;
     }
-    if (value == 'inherit') {
-      // TODO: Other keywords
-      throw new TypeError('Not implemented yet');
+
+    if (scope.KeywordValue.isKeywordValue(value)) {
+      return new scope.KeywordValue(value);
     }
 
     // TODO: The rest of the properties once the rest of the StyleValues are
@@ -55,6 +55,31 @@
       case 'widows':
       case 'z-index':
         return new scope.NumberValue(value);
+
+      // These properties take only a length value (length and percentage),
+      // or a keyword handled above.
+      case 'bottom':
+      case 'height':
+      case 'left':
+      case 'max-height':
+      case 'max-width':
+      case 'min-height':
+      case 'min-width':
+      case 'right':
+      case 'text-indent':
+      case 'top':
+      case 'width':
+        // TODO: ensure that LengthValue.parse is being implemented,
+        // or update to other appropriate function.
+        return new scope.LengthValue.parse(value);
+
+      // These properties only take a length value, but do not take percentage.
+      // TODO: Validation and implementation of this case.
+      case 'letter-spacing':
+      case 'word-spacing':
+        throw new TypeError('Not implemented yet');
+
+      // These properties take a number or SimpleLength
 
       case 'line-height':
         // normal | <number> | <length> | <percentage> | inherit
@@ -82,15 +107,28 @@
 
     switch (property) {
       // These properties always return a single value.
+      case 'bottom':
+      case 'height':
+      case 'left':
+      case 'letter-spacing':
       case 'line-height':
+      case 'max-height':
+      case 'max-width':
+      case 'min-height':
+      case 'min-width':
       case 'opacity':
       case 'orphans':
       case 'pitch-range':
       case 'richness':
+      case 'right':
       case 'speech-rate':
       case 'stress':
+      case 'text-indent':
+      case 'top':
       case 'volume':
       case 'widows':
+      case 'width':
+      case 'word-spacing':
       case 'z-index':
         var value = this.get(property);
         return value ? [value] : [];

--- a/src/computed-style-property-map.js
+++ b/src/computed-style-property-map.js
@@ -105,40 +105,13 @@
       throw new TypeError('parameter 1 is not of type \'string\'');
     }
 
-    switch (property) {
-      // These properties always return a single value.
-      case 'bottom':
-      case 'height':
-      case 'left':
-      case 'letter-spacing':
-      case 'line-height':
-      case 'max-height':
-      case 'max-width':
-      case 'min-height':
-      case 'min-width':
-      case 'opacity':
-      case 'orphans':
-      case 'pitch-range':
-      case 'richness':
-      case 'right':
-      case 'speech-rate':
-      case 'stress':
-      case 'text-indent':
-      case 'top':
-      case 'volume':
-      case 'widows':
-      case 'width':
-      case 'word-spacing':
-      case 'z-index':
-        var value = this.get(property);
-        return value ? [value] : [];
-
-      // TODO: Stuff that takes shorthands will need to be handled separately.
-
-      default:
-        throw new TypeError('Not implemented yet');
+    var value = this.get(property);
+    if (Array.isArray(value)) {
+      // TODO: Handle shorthands
+      throw new TypeError('Not implemented yet');
+    } else {
+      return value ? [value] : [];
     }
-
   };
 
   ComputedStylePropertyMap.prototype.set = function(property, value) {

--- a/src/keyword-value.js
+++ b/src/keyword-value.js
@@ -22,7 +22,7 @@
     this.cssString = value;
   }
 
-  KeywordValue.StyleValueKeyword = ['initial', 'inherit', 'revert', 'unset'];
+  KeywordValue.StyleValueKeyword = ['auto', 'initial', 'inherit', 'revert', 'unset'];
 
   KeywordValue.isKeywordValue = function(cssString) {
     return KeywordValue.StyleValueKeyword.indexOf(cssString) >= 0;

--- a/test/js/computed-style-property-map.js
+++ b/test/js/computed-style-property-map.js
@@ -3,6 +3,9 @@ suite('ComputedStylePropertyMap', function() {
     this.element = document.createElement('div');
     document.documentElement.appendChild(this.element);
     this.element.style.opacity = '0.5';
+    this.element.style.height = '100px';
+    this.element.style.width = 'calc(50px+10em)';
+    this.element.style.right = 'inherit';
   });
   teardown(function() {
     document.documentElement.removeChild(this.element);
@@ -31,5 +34,36 @@ suite('ComputedStylePropertyMap', function() {
     assert.instanceOf(opacity, NumberValue);
     assert.equal(opacity.value, 0.5);
     assert.equal(opacity.cssString, '0.5');
+  });
+
+  // NOTE: window.getComputedStyle(element)[property] in
+  // ComputedStylePropertyMap.get is the resolved style,
+  // so tests need to be written accordingly.
+  test.skip('ComputedStylePropertyMap.get works for KeywordValues', function() {
+    var computedStyleMap = new ComputedStylePropertyMap(this.element);
+    var right = computedStyleMap.get('right');
+    assert.instanceOf(right, KeywordValue);
+    assert.instanceOf(right, StyleValue);
+    // TODO: check what inherit resolves to.
+  });
+
+  test.skip('ComputedStylePropertyMap.get works for properties that can only be LengthValues', function() {
+    var computedStyleMap = new ComputedStylePropertyMap(this.element);
+    var height = computedStyleMap.get('height');
+    assert.instanceOf(height, LengthValue);
+    assert.instanceOf(height, SimpleLength);
+    assert.equal(height.value, 100);
+    assert.equal(height.type, 'px');
+    assert.equal(height.cssString, '100px');
+  });
+
+  test.skip('ComputedStylePropertyMap.get works for properties with CalcLengths', function() {
+    var computedStyleMap = new ComputedStylePropertyMap(this.element);
+    var width = computedStyleMap.get('width');
+    assert.instanceOf(width, LengthValue);
+    assert.instanceOf(width, CalcLength);
+    assert.equal(width.px, 50);
+    assert.equal(width.em, 10);
+    assert.equal(width.cssString, 'calc(50px+10em)');
   });
 });

--- a/test/js/computed-style-property-map.js
+++ b/test/js/computed-style-property-map.js
@@ -23,8 +23,8 @@ suite('ComputedStylePropertyMap', function() {
     var computedStyleMap = new ComputedStylePropertyMap(this.element);
     var opacity = computedStyleMap.get('opacity');
     assert.instanceOf(opacity, NumberValue);
-    assert.equal(opacity.value, 0.5);
-    assert.equal(opacity.cssString, '0.5');
+    assert.strictEqual(opacity.value, 0.5);
+    assert.strictEqual(opacity.cssString, '0.5');
   });
 
   test('window.getComputedStyleMap works', function() {
@@ -32,19 +32,18 @@ suite('ComputedStylePropertyMap', function() {
     assert.instanceOf(computedStyleMap, typedOMTesting.StylePropertyMap);
     var opacity = computedStyleMap.get('opacity');
     assert.instanceOf(opacity, NumberValue);
-    assert.equal(opacity.value, 0.5);
-    assert.equal(opacity.cssString, '0.5');
+    assert.strictEqual(opacity.value, 0.5);
+    assert.strictEqual(opacity.cssString, '0.5');
   });
 
-  // NOTE: window.getComputedStyle(element)[property] in
-  // ComputedStylePropertyMap.get is the resolved style,
-  // so tests need to be written accordingly.
-  test.skip('ComputedStylePropertyMap.get works for KeywordValues', function() {
+  test('ComputedStylePropertyMap.get works for KeywordValues', function() {
     var computedStyleMap = new ComputedStylePropertyMap(this.element);
     var right = computedStyleMap.get('right');
     assert.instanceOf(right, KeywordValue);
     assert.instanceOf(right, StyleValue);
-    // TODO: check what inherit resolves to.
+    // 'inherit' resolves to 'auto' in this case
+    assert.strictEqual(right.keywordValue, 'auto');
+    assert.strictEqual(right.cssString, 'auto');
   });
 
   test.skip('ComputedStylePropertyMap.get works for properties that can only be LengthValues', function() {
@@ -52,9 +51,9 @@ suite('ComputedStylePropertyMap', function() {
     var height = computedStyleMap.get('height');
     assert.instanceOf(height, LengthValue);
     assert.instanceOf(height, SimpleLength);
-    assert.equal(height.value, 100);
-    assert.equal(height.type, 'px');
-    assert.equal(height.cssString, '100px');
+    assert.strictEqual(height.value, 100);
+    assert.strictEqual(height.type, 'px');
+    assert.strictEqual(height.cssString, '100px');
   });
 
   test.skip('ComputedStylePropertyMap.get works for properties with CalcLengths', function() {
@@ -62,8 +61,8 @@ suite('ComputedStylePropertyMap', function() {
     var width = computedStyleMap.get('width');
     assert.instanceOf(width, LengthValue);
     assert.instanceOf(width, CalcLength);
-    assert.equal(width.px, 50);
-    assert.equal(width.em, 10);
-    assert.equal(width.cssString, 'calc(50px+10em)');
+    assert.strictEqual(width.px, 50);
+    assert.strictEqual(width.em, 10);
+    assert.strictEqual(width.cssString, 'calc(50px+10em)');
   });
 });

--- a/test/js/keyword-value.js
+++ b/test/js/keyword-value.js
@@ -18,6 +18,7 @@ suite('KeywordValue', function() {
   });
 
   test('KeywordValue.isKeywordValue is true for valid values', function() {
+    assert.isTrue(KeywordValue.isKeywordValue('auto'));
     assert.isTrue(KeywordValue.isKeywordValue('initial'));
     assert.isTrue(KeywordValue.isKeywordValue('inherit'));
     assert.isTrue(KeywordValue.isKeywordValue('revert'));


### PR DESCRIPTION
- adds a list of properties that take length values
  to ComputedStylePropertyMap
  - adds a check for keywords
    NOTE: this may have to change / move around
  - adds some basic tests for length and keyword values
    for the map
    NOTE: These tests are currently being skipped as
     parsing is unimplemented.
  - adds `auto` keyword to KeywordValue
  - alter KeywordValue related tests as appropriate
