### PR TITLE
Small cleanup

### DIFF
--- a/src/calc-length.js
+++ b/src/calc-length.js
@@ -14,10 +14,7 @@
 
 (function(shared, scope, testing) {
 
-  /**
-   * CalcLength(dictionary)
-   * TODO: CalcLength(cssString)
-   */
+  // TODO: CalcLength(cssString)
   function CalcLength(dictionary) {
     if (typeof dictionary != 'object') {
       throw new TypeError('CalcLength must be passed a dictionary object');
@@ -68,7 +65,7 @@
   CalcLength.prototype.multiply = function(multiplier) {
     var calcDictionary = {};
 
-    // Iterate through all length types and multiply all non null lengths 
+    // Iterate through all length types and multiply all non null lengths
     for(var i = 0; i < shared.LengthValue.LengthType.length; i++){
       var type = shared.LengthValue.LengthType[i];
       if(this[type] != null){
@@ -82,7 +79,7 @@
   CalcLength.prototype.divide = function(divider) {
     var calcDictionary = {};
 
-    // Iterate through all length types and divide all non null lengths 
+    // Iterate through all length types and divide all non null lengths
     for(var i = 0; i < shared.LengthValue.LengthType.length; i++){
       var type = shared.LengthValue.LengthType[i];
       if(this[type] != null){

--- a/src/length-value.js
+++ b/src/length-value.js
@@ -50,7 +50,7 @@
   LengthValue.prototype.add = function(addedLength) {
     if (this instanceof SimpleLength && addedLength instanceof SimpleLength && this.type == addedLength.type) {
       return this._addSimpleLengths(addedLength);
-    } 
+    }
     throw new TypeError('Not implemented yet');
   };
 

--- a/src/simple-length.js
+++ b/src/simple-length.js
@@ -14,10 +14,7 @@
 
 (function(shared, scope, testing) {
 
-  /**
-   * SimpleLength(value, type)
-   * TODO: SimpleLength(simpleLength), SimpleLength(cssString)
-   */
+  // TODO: SimpleLength(simpleLength), SimpleLength(cssString)
   function SimpleLength(value, type) {
     if (arguments.length == 2 && shared.LengthValue.LengthType.indexOf(type) >= 0) {
       this.type = type;
@@ -50,7 +47,7 @@
   SimpleLength.prototype._addSimpleLengths = function(addedLength) {
     if (!(addedLength instanceof SimpleLength)) {
       throw new TypeError('Objects not of type simple length');
-    } 
+    }
     if (this.type != addedLength.type) {
       throw new TypeError('SimpleLength units are not the same');
     }
@@ -60,7 +57,7 @@
   SimpleLength.prototype._subtractSimpleLengths = function(subtractedLength) {
     if (!(subtractedLength instanceof SimpleLength)) {
       throw new TypeError('Objects not of type simple length');
-    } 
+    }
     if (this.type != subtractedLength.type) {
       throw new TypeError('SimpleLength units are not the same');
     }

--- a/test/js/simple-length.js
+++ b/test/js/simple-length.js
@@ -73,18 +73,18 @@ suite('SimpleLength', function() {
   });
 
   test('Adding two SimpleLength of the same kind returns a new SimpleLength of the same kind', function() {
-    var length_1 = new SimpleLength(10, 'em');
-    var length_2 = new SimpleLength(5, 'em');
-    var lengthAddition = length_1.add(length_2);
+    var length1 = new SimpleLength(10, 'em');
+    var length2 = new SimpleLength(5, 'em');
+    var lengthAddition = length1.add(length2);
     assert.instanceOf(lengthAddition, SimpleLength, 'two added SimpleLength of same type should be an instance of SimpleLength');
     assert.strictEqual(lengthAddition.type, 'em');
     assert.strictEqual(lengthAddition.value, 15);
   });
 
   test('subtracting two SimpleLength of the same kind returns a new SimpleLength of the same kind', function() {
-    var length_1 = new SimpleLength(10, 'em');
-    var length_2 = new SimpleLength(5, 'em');
-    var lengthAddition = length_1.subtract(length_2);
+    var length1 = new SimpleLength(10, 'em');
+    var length2 = new SimpleLength(5, 'em');
+    var lengthAddition = length1.subtract(length2);
     assert.instanceOf(lengthAddition, SimpleLength, 'two subtracted SimpleLength of same type should be an instance of SimpleLength');
     assert.strictEqual(lengthAddition.type, 'em');
     assert.strictEqual(lengthAddition.value, 5);

--- a/test/js/simple-length.js
+++ b/test/js/simple-length.js
@@ -57,7 +57,7 @@ suite('SimpleLength', function() {
     assert.strictEqual(calcOutput.type, 'px');
     assert.strictEqual(calcOutput.value, (5.3 * 3));
   });
- 
+
   test('Division of a SimpleLength produces a new SimpleLength object', function() {
     var simpleLength = new SimpleLength(27, 'px');
     var calcOutput = simpleLength.divide(3);


### PR DESCRIPTION
Make comment delimiters consistent. Remove comments that mirror function signatures (redundant). Remove trailing whitespace.

@nattridgell @wilddamon @njlawton 
