### PR TITLE
Error for when SimpleLength is constructed with an invalid type arg.

### DIFF
--- a/src/computed-style-property-map.js
+++ b/src/computed-style-property-map.js
@@ -54,7 +54,7 @@
       case 'stress':
       case 'widows':
       case 'z-index':
-        return new scope.NumberValue(value);
+        return new scope.NumberValue(Number(value));
 
       case 'line-height':
         // normal | <number> | <length> | <percentage> | inherit

--- a/src/number-value.js
+++ b/src/number-value.js
@@ -15,21 +15,11 @@
 (function(shared, scope, testing) {
 
   function NumberValue(value) {
-    this.cssString = '' + value;
-    if (typeof value == 'number') {
-      this.value = value;
-    } else if (typeof value == 'string') {
-      var nValue = Number.parseFloat(value);
-      if (!isNaN(nValue)) {
-        this.value = nValue;
-      } else {
-        throw new TypeError(
-          'Value of NumberValue must be a number or a numeric string.');
-      }
-    } else {
-      throw new TypeError(
-        'Value of NumberValue must be a number or a numeric string.');
+    if (typeof value != 'number') {
+      throw new TypeError('Value of NumberValue must be a number.');
     }
+    this.value = value;
+    this.cssString = '' + value;
   }
 
   NumberValue.prototype = Object.create(shared.StyleValue.prototype);

--- a/src/simple-length.js
+++ b/src/simple-length.js
@@ -16,21 +16,14 @@
 
   // TODO: SimpleLength(simpleLength), SimpleLength(cssString)
   function SimpleLength(value, type) {
-    if (arguments.length == 2 && shared.LengthValue.LengthType.indexOf(type) >= 0) {
-      this.type = type;
-      if (typeof value == 'number') {
-        this.value = value;
-      } else if (typeof value == 'string') {
-        var nValue = Number.parseFloat(value);
-        if (!isNaN(nValue)) {
-          this.value = nValue;
-        }
-      }
+    if (typeof value != 'number') {
+      throw new TypeError('Value of SimpleLength must be a number.');
     }
-    if (this.value == undefined) {
-      throw new TypeError('Value of SimpleLength must be a number or a numeric string.');
+    if (shared.LengthValue.LengthType.indexOf(type) < 0) {
+      throw new TypeError('\'' + type + '\' is not a valid type for a SimpleLength.');
     }
-
+    this.type = type;
+    this.value = value;
     this.cssString = this.value + shared.LengthValue.cssStringTypeRepresentation(this.type);
   }
 

--- a/test/js/computed-style-property-map.js
+++ b/test/js/computed-style-property-map.js
@@ -2,7 +2,7 @@ suite('ComputedStylePropertyMap', function() {
   setup(function() {
     this.element = document.createElement('div');
     document.documentElement.appendChild(this.element);
-    this.element.style.opacity = '0.5';
+    this.element.style.opacity = 0.5;
   });
   teardown(function() {
     document.documentElement.removeChild(this.element);

--- a/test/js/number-value.js
+++ b/test/js/number-value.js
@@ -9,21 +9,15 @@ suite('NumberValue', function() {
 
   test('NumberValue constructor throws exception for invalid values',
       function() {
-    assert.throws(function() {new NumberValue('a4')});
+    assert.throws(function() {new NumberValue('4')});
     assert.throws(function() {new NumberValue({})});
   });
 
   test('NumberValue constructor works correctly for numbers and numeric ' +
       'strings', function() {
-    var numberValFromString;
-    assert.doesNotThrow(function() {
-      numberValFromString = new NumberValue('9.2');
-    });
-    assert.strictEqual(numberValFromString.cssString, '9.2');
-    assert.strictEqual(numberValFromString.value, 9.2);
-    var numberValFromNumber;
-    assert.doesNotThrow(function() {numberValFromNumber = new NumberValue(10)});
-    assert.strictEqual(numberValFromNumber.cssString, '10');
-    assert.strictEqual(numberValFromNumber.value, 10);
+    var value;
+    assert.doesNotThrow(function() {value = new NumberValue(10)});
+    assert.strictEqual(value.cssString, '10');
+    assert.strictEqual(value.value, 10);
   });
 });

--- a/test/js/simple-length.js
+++ b/test/js/simple-length.js
@@ -13,27 +13,18 @@ suite('SimpleLength', function() {
   });
 
   // Possible constructors: SimpleLength(SimpleLength),
-  // SimpleLength(number, type), SimpleLength(numeric string, type)
-  test('SimpleLength constructor works correctly for numbers and numeric strings', function() {
-    var valueFromString;
-    assert.doesNotThrow(function() {valueFromString = new SimpleLength('9.2', 'px')});
-    assert.strictEqual(valueFromString.type, 'px');
-    assert.strictEqual(valueFromString.value, 9.2);
-
-    var valueFromNumber;
-    assert.doesNotThrow(function() {valueFromNumber = new SimpleLength(10, 'px')});
-    assert.strictEqual(valueFromNumber.type, 'px');
-    assert.strictEqual(valueFromNumber.value, 10);
+  // SimpleLength(number, type)
+  test('SimpleLength constructor works correctly for numbers', function() {
+    var result;
+    assert.doesNotThrow(function() {result = new SimpleLength(10, 'px')});
+    assert.strictEqual(result.type, 'px');
+    assert.strictEqual(result.value, 10);
   });
 
   test('SimpleLength cssString is correctly defined for different values and types', function() {
-    var valueFromString;
-    assert.doesNotThrow(function() {valueFromString = new SimpleLength('9.2', 'px')});
-    assert.strictEqual(valueFromString.cssString, '9.2px');
-
-    var valueFromNumber;
-    assert.doesNotThrow(function() {valueFromNumber = new SimpleLength(10, 'px')});
-    assert.strictEqual(valueFromNumber.cssString, '10px');
+    var pixValue;
+    assert.doesNotThrow(function() {pixValue = new SimpleLength(10, 'px')});
+    assert.strictEqual(pixValue.cssString, '10px');
 
     var percentValue;
     assert.doesNotThrow(function() {percentValue = new SimpleLength(10, 'percent')});


### PR DESCRIPTION
- Add error message for when SimpleLength is constructed with an invalid type arg
- Switch to not accepting numeric strings in NumberValue and SimpleLength constructors
