### PR TITLE
Small style cleanup, mainly scope stuff

### DIFF
--- a/src/calc-length.js
+++ b/src/calc-length.js
@@ -12,7 +12,7 @@
 //     See the License for the specific language governing permissions and
 // limitations under the License.
 
-(function(internal, scope, testing) {
+(function(internal, scope) {
 
   // TODO: CalcLength(cssString)
   function CalcLength(dictionary) {
@@ -158,7 +158,5 @@
   };
 
   scope.CalcLength = CalcLength;
-  if (TYPED_OM_TESTING)
-    testing.CalcLength = CalcLength;
 
-})(typedOM.internal, window, typedOMTesting);
+})(typedOM.internal, window);

--- a/src/keyword-value.js
+++ b/src/keyword-value.js
@@ -12,7 +12,7 @@
 //     See the License for the specific language governing permissions and
 // limitations under the License.
 
-(function(internal, scope, testing) {
+(function(internal, scope) {
 
   function KeywordValue(value) {
     if (!KeywordValue.isKeywordValue(value)) {
@@ -30,7 +30,5 @@
   };
 
   scope.KeywordValue = KeywordValue;
-  if (TYPED_OM_TESTING)
-    testing.KeywordValue = KeywordValue;
 
-})(typedOM.internal, window, typedOMTesting);
+})(typedOM.internal, window);

--- a/src/length-value.js
+++ b/src/length-value.js
@@ -88,7 +88,8 @@
   };
 
   internal.LengthValue = LengthValue;
-  if (TYPED_OM_TESTING)
+  if (TYPED_OM_TESTING) {
     testing.LengthValue = LengthValue;
+  }
 
 })(typedOM.internal, typedOMTesting);

--- a/src/number-value.js
+++ b/src/number-value.js
@@ -12,7 +12,7 @@
 //     See the License for the specific language governing permissions and
 // limitations under the License.
 
-(function(internal, scope, testing) {
+(function(internal, scope) {
 
   function NumberValue(value) {
     if (typeof value != 'number') {
@@ -24,8 +24,6 @@
   internal.inherit(NumberValue, internal.StyleValue);
 
   scope.NumberValue = NumberValue;
-  if (TYPED_OM_TESTING)
-    testing.NumberValue = NumberValue;
 
-})(typedOM.internal, window, typedOMTesting);
+})(typedOM.internal, window);
 

--- a/src/position-value.js
+++ b/src/position-value.js
@@ -12,7 +12,7 @@
 //     See the License for the specific language governing permissions and
 // limitations under the License.
 
-(function(internal, scope, testing) {
+(function(internal, scope) {
 
   /**
    * PositionValue(xPos, yPos)
@@ -37,7 +37,5 @@
   };
 
   scope.PositionValue = PositionValue;
-  if (TYPED_OM_TESTING)
-    testing.PositionValue = PositionValue;
 
-})(typedOM.internal, window, typedOMTesting);
+})(typedOM.internal, window);

--- a/src/scope.js
+++ b/src/scope.js
@@ -14,7 +14,8 @@
 
 typedOM = {};
 typedOM.internal = {};
-if (TYPED_OM_TESTING)
+if (TYPED_OM_TESTING) {
   var typedOMTesting = window;
-else
+} else {
   var typedOMTesting = null;
+}

--- a/src/simple-length.js
+++ b/src/simple-length.js
@@ -12,7 +12,7 @@
 //     See the License for the specific language governing permissions and
 // limitations under the License.
 
-(function(internal, scope, testing) {
+(function(internal, scope) {
 
   // TODO: SimpleLength(simpleLength), SimpleLength(cssString)
   function SimpleLength(value, type) {
@@ -73,7 +73,5 @@
   };
 
   scope.SimpleLength = SimpleLength;
-  if (TYPED_OM_TESTING)
-    testing.SimpleLength = SimpleLength;
 
-})(typedOM.internal, window, typedOMTesting);
+})(typedOM.internal, window);

--- a/src/style-property-map.js
+++ b/src/style-property-map.js
@@ -12,7 +12,7 @@
 //     See the License for the specific language governing permissions and
 // limitations under the License.
 
-(function(internal, scope, testing) {
+(function(internal, testing) {
 
   function StylePropertyMap(styleObject) {
     this._styleObject = styleObject;
@@ -36,7 +36,8 @@
   };
 
   internal.StylePropertyMap = StylePropertyMap;
-  if (TYPED_OM_TESTING)
+  if (TYPED_OM_TESTING) {
     testing.StylePropertyMap = StylePropertyMap;
+  }
 
-})(typedOM.internal, window, typedOMTesting);
+})(typedOM.internal, typedOMTesting);

--- a/src/style-value.js
+++ b/src/style-value.js
@@ -28,7 +28,8 @@
   };
 
   internal.StyleValue = StyleValue;
-  if (TYPED_OM_TESTING)
+  if (TYPED_OM_TESTING) {
     testing.StyleValue = StyleValue;
+  }
 
 })(typedOM.internal, window, typedOMTesting);

--- a/target-config.js
+++ b/target-config.js
@@ -52,8 +52,9 @@
     },
   };
 
-  if (typeof module != 'undefined')
+  if (typeof module != 'undefined') {
     module.exports = targetConfig;
-  else
+  } else {
     window.typedOMTargetConfig = targetConfig;
+  }
 })();

--- a/test/js/computed-style-property-map.js
+++ b/test/js/computed-style-property-map.js
@@ -1,11 +1,11 @@
 suite('Computed StylePropertyMap', function() {
   setup(function() {
     this.element = document.createElement('div');
-    document.documentElement.appendChild(this.element);
+    document.body.appendChild(this.element);
     this.element.style.opacity = 0.5;
   });
   teardown(function() {
-    document.documentElement.removeChild(this.element);
+    document.body.removeChild(this.element);
   });
 
   test('Computed StylePropertyMapReadOnly.get works for properties that can be NumberValues', function() {


### PR DESCRIPTION
- Functions exposed on scope don't need to be on testing
- Remove unneeded scope arguments
- One-line blocks should have braces around them
- Don't add elements to documentElement for testing
