### PR TITLE
Add Skew (a TransformComponent)

### DIFF
--- a/src/skew.js
+++ b/src/skew.js
@@ -1,0 +1,57 @@
+// Copyright 2015 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//     You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//     See the License for the specific language governing permissions and
+// limitations under the License.
+
+(function(internal, scope) {
+
+  function Skew(ax, ay) {
+    if (arguments.length != 2) {
+      throw new TypeError('Skew must have 2 arguments.');
+    } else if (typeof ax != 'number' || typeof ay != 'number') {
+      throw new TypeError('Skew arguments must be of type \'number\'.');
+    }
+
+    this.ax = ax;
+    this.ay = ay;
+
+    this._computeMatrix();
+    this._generateCssString();
+  }
+  internal.inherit(Skew, internal.TransformComponent);
+
+  Skew._tanDegrees = function(degrees) {
+    var radians = degrees * Math.PI / 180;
+    return Math.tan(radians);
+  };
+
+  Skew.prototype.asMatrix = function() {
+    return this._matrix;
+  };
+
+  Skew.prototype._computeMatrix = function() {
+    // Skew represented by the 2D matrix:
+    //   1     tan(ax)  0
+    // tan(ay)    1     0
+
+    var tanAx = Skew._tanDegrees(this.ax);
+    var tanAy = Skew._tanDegrees(this.ay);
+    this._matrix = new Matrix(1, tanAy, tanAx, 1, 0, 0);
+  };
+
+  Skew.prototype._generateCssString = function() {
+    this.cssString = 'skew(' + this.ax + ', ' + this.ay + ')';
+  };
+
+  scope.Skew = Skew;
+
+})(typedOM.internal, window);

--- a/target-config.js
+++ b/target-config.js
@@ -30,6 +30,7 @@
       'src/transform-component.js',
       'src/matrix.js',
       'src/scale.js',
+      'src/skew.js',
       'src/style-property-map-readonly.js',
       'src/style-property-map.js'
   ];
@@ -44,6 +45,7 @@
       'test/js/transform-component.js',
       'test/js/matrix.js',
       'test/js/scale.js',
+      'test/js/skew.js',
       'test/js/computed-style-property-map.js',
       'test/js/inline-style-property-map.js'
   ];

--- a/test/js/skew.js
+++ b/test/js/skew.js
@@ -1,0 +1,42 @@
+suite('Skew', function() {
+  test('Skew is a Skew and TransformComponent', function() {
+    var skew = new Skew(1, 2);
+    assert.instanceOf(skew, Skew, 'A new Skew should be an instance of Skew');
+    assert.instanceOf(skew, TransformComponent,
+        'A new Skew should be an instance of TransformComponent');
+  });
+
+  test('Skew constructor throws exception for invalid types', function() {
+    assert.throws(function() {new Skew()});
+    assert.throws(function() {new Skew({})});
+    assert.throws(function() {new Skew({}, {})});
+    assert.throws(function() {new Skew(1)});
+    assert.throws(function() {new Skew('1', '2')});
+    assert.throws(function() {new Skew(3, null)});
+    assert.throws(function() {new Skew(1, 2, 3)});
+  });
+
+  test('Skew constructor works correctly', function() {
+    var skew;
+    assert.doesNotThrow(function() {skew = new Skew(30, 180)});
+    assert.strictEqual(skew.cssString, 'skew(30, 180)');
+    assert.strictEqual(skew.ax, 30);
+    assert.strictEqual(skew.ay, 180);
+    assert.isTrue(skew.is2DComponent());
+
+    var tanAx = Skew._tanDegrees(30);
+    var tanAy = Skew._tanDegrees(180);
+
+    var expectedMatrix = new Matrix(1, tanAy, tanAx, 1, 0, 0);
+    assert.strictEqual(skew.asMatrix().cssString, expectedMatrix.cssString);
+    assert.deepEqual(skew.asMatrix(), expectedMatrix);
+  });
+
+  test('Skew._tanDegrees works correctly', function() {
+    var delta = 0.000001;
+    assert.closeTo(Skew._tanDegrees(0), Math.tan(0), delta);
+    assert.closeTo(Skew._tanDegrees(30), Math.tan(Math.PI / 6), delta);
+    assert.closeTo(Skew._tanDegrees(60), Math.tan(Math.PI / 3), delta);
+    assert.closeTo(Skew._tanDegrees(180), Math.tan(Math.PI), delta);
+  });
+});


### PR DESCRIPTION
Key points for Skew:
- always 2d component
- constructor takes (ax, ay), which are both angles in degrees.
- 2D matrix constructed in column-major order is:
  [1, tan(ay), tan(ax), 1, 0, 0]

Note: for all TransformComponents, use internal methods in constructor:
- _computeMatrix
- _generateCssString
