### PR TITLE
StylePropertyMap set method implemented 

### DIFF
--- a/src/style-property-map.js
+++ b/src/style-property-map.js
@@ -27,16 +27,19 @@
 
     if (value instanceof StyleValue) {
       if (!cssPropertyDictionary.isValidInput(property, value)) {
-        throw new TypeError('This StyleValue type cannot be set to this property');
+        throw new TypeError(
+          'This StyleValue type cannot be set to this property');
       }
       this._styleObject[property] = value.cssString;
       return;
     }
 
     if (value instanceof Array) {
-      throw new TypeError('Setting a sequence of StyleValues is not implemented yet');
+      throw new TypeError(
+        'Setting a sequence of StyleValues is not implemented yet');
     }
-    throw new TypeError('The value you are setting must be a StyleValue object');
+    throw new TypeError(
+      'The value you are setting must be a StyleValue object');
   };
 
   StylePropertyMap.prototype.append = function(property, value) {

--- a/src/style-property-map.js
+++ b/src/style-property-map.js
@@ -34,12 +34,14 @@
       throw new TypeError(
         'The value must be a StyleValue or sequence of StyleValues');
     }
-      
+
     if (!cssPropertyDictionary.isValidInput(property, value)) {
-      if(value instanceof KeywordValue) {
-        throw new TypeError(property + ' does not take the keyword ' + value.cssString);
+      if (value instanceof KeywordValue) {
+        throw new TypeError(property +
+          ' does not take the keyword ' + value.cssString);
       }
-      throw new TypeError(property + ' does not take values of type ' + value.constructor.name);
+      throw new TypeError(property +
+        ' does not take values of type ' + value.constructor.name);
     }
     this._styleObject[property] = value.cssString;
   };

--- a/src/style-property-map.js
+++ b/src/style-property-map.js
@@ -20,7 +20,23 @@
   internal.inherit(StylePropertyMap, internal.StylePropertyMapReadOnly);
 
   StylePropertyMap.prototype.set = function(property, value) {
-    throw new TypeError('Function not implemented yet');
+    var cssPropertyDictionary = propertyDictionary();
+    if (!cssPropertyDictionary.isSupportedProperty(property)) {
+      throw new TypeError(property + 'Is not a Supported CSS property');
+    }
+
+    if (value instanceof StyleValue) {
+      if (!cssPropertyDictionary.isValidInput(property, value)) {
+        throw new TypeError('This StyleValue type cannot be set to this property');
+      }
+      this._styleObject[property] = value.cssString;
+      return;
+    }
+
+    if (value instanceof Array) {
+      throw new TypeError('Setting a sequence of StyleValues is not implemented yet');
+    }
+    throw new TypeError('The value you are setting must be a StyleValue object');
   };
 
   StylePropertyMap.prototype.append = function(property, value) {

--- a/src/style-property-map.js
+++ b/src/style-property-map.js
@@ -22,24 +22,26 @@
   StylePropertyMap.prototype.set = function(property, value) {
     var cssPropertyDictionary = propertyDictionary();
     if (!cssPropertyDictionary.isSupportedProperty(property)) {
-      throw new TypeError(property + 'Is not a Supported CSS property');
-    }
-
-    if (value instanceof StyleValue) {
-      if (!cssPropertyDictionary.isValidInput(property, value)) {
-        throw new TypeError(
-          'This StyleValue type cannot be set to this property');
-      }
-      this._styleObject[property] = value.cssString;
-      return;
+      throw new TypeError(property + 'is not a supported CSS property');
     }
 
     if (value instanceof Array) {
       throw new TypeError(
         'Setting a sequence of StyleValues is not implemented yet');
     }
-    throw new TypeError(
-      'The value you are setting must be a StyleValue object');
+
+    if (!value instanceof StyleValue) {
+      throw new TypeError(
+        'The value must be a StyleValue or sequence of StyleValues');
+    }
+      
+    if (!cssPropertyDictionary.isValidInput(property, value)) {
+      if(value instanceof KeywordValue) {
+        throw new TypeError(property + ' does not take the keyword ' + value.cssString);
+      }
+      throw new TypeError(property + ' does not take values of type ' + value.constructor.name);
+    }
+    this._styleObject[property] = value.cssString;
   };
 
   StylePropertyMap.prototype.append = function(property, value) {

--- a/test/js/inline-style-property-map.js
+++ b/test/js/inline-style-property-map.js
@@ -40,4 +40,10 @@ suite('Inline StylePropertyMap', function() {
 
     assert.throw(function() {inlineStyleMap.set('height', 4)}, TypeError);
   });
+
+  test('The set method should throw a TypeError if an unsupported property is inputed into the function', function() {
+    var inlineStyleMap = this.element.styleMap();
+
+    assert.throw(function() {inlineStyleMap.set('lemons', new SimpleLength(3, 'px'))}, TypeError);
+  });
 });

--- a/test/js/inline-style-property-map.js
+++ b/test/js/inline-style-property-map.js
@@ -21,7 +21,7 @@ suite('Inline StylePropertyMap', function() {
     assert.strictEqual(this.element.style['height'], simpleLength.cssString);
   });
 
-  test('The set method should throw a TypeError if a StyleValue unsupported by the CSS style property is set', function() {
+  test('The set method should throw a TypeError if a non KeywordValue StyleValue unsupported by the CSS style property is set', function() {
     var inlineStyleMap = this.element.styleMap();
     var numberValue = new NumberValue(42);
 

--- a/test/js/inline-style-property-map.js
+++ b/test/js/inline-style-property-map.js
@@ -8,8 +8,38 @@ suite('Inline StylePropertyMap', function() {
     document.body.removeChild(this.element);
   });
 
-  test('Element.styleMap method returns a StylePropertyMap object', function() {
+  test('Element.styleMap method returns a StylePropertyMap object for that element', function() {
     var inlineStyleMap = this.element.styleMap();
-    assert.instanceOf(inlineStyleMap, StylePropertyMap, 'The styleMap method should return an instance of StylePropertyMap');
+    assert.instanceOf(inlineStyleMap, StylePropertyMap);
+  });
+
+  test('The set method should correctly set a supported StyleValue to a CSS style property of an HTML element', function() {
+    var inlineStyleMap = this.element.styleMap();
+    var simpleLength = new SimpleLength(9.2, 'percent');
+    inlineStyleMap.set('height', simpleLength);
+
+    assert.strictEqual(this.element.style['height'], simpleLength.cssString);
+  });
+
+  test('The set method should correctly set a supported KeywordValue to a CSS style property of an HTML element', function() {
+    var inlineStyleMap = this.element.styleMap();
+    var keyword = new KeywordValue('auto');
+    inlineStyleMap.set('height', keyword);
+
+    assert.strictEqual(this.element.style['height'], keyword.cssString);
+  });
+
+  test('The set method should throw a TypeError if a StyleValue unsupported by the CSS style property is set', function() {
+    var inlineStyleMap = this.element.styleMap();
+    var numberValue = new NumberValue(42);
+
+    assert.throw(function() {inlineStyleMap.set('height', numberValue)}, TypeError);
+  });
+
+  test('The set method should throw a TypeError if a KeywordValue unsupported by the CSS style property is set ', function() {
+    var inlineStyleMap = this.element.styleMap();
+    var keyword = new KeywordValue('lemon');
+
+    assert.throw(function() {inlineStyleMap.set('height', keyword)}, TypeError);
   });
 });

--- a/test/js/inline-style-property-map.js
+++ b/test/js/inline-style-property-map.js
@@ -8,25 +8,17 @@ suite('Inline StylePropertyMap', function() {
     document.body.removeChild(this.element);
   });
 
-  test('the Element.styleMap method returns a StylePropertyMap object for that element', function() {
+  test('The Element.styleMap method returns a StylePropertyMap object for that element', function() {
     var inlineStyleMap = this.element.styleMap();
     assert.instanceOf(inlineStyleMap, StylePropertyMap);
   });
 
-  test('The set method should correctly set a supported StyleValue to a CSS style property of an HTML element', function() {
+  test('The set method successfully sets the CSS string of the StyleValue on an element', function() {
     var inlineStyleMap = this.element.styleMap();
     var simpleLength = new SimpleLength(9.2, 'percent');
     inlineStyleMap.set('height', simpleLength);
 
     assert.strictEqual(this.element.style['height'], simpleLength.cssString);
-  });
-
-  test('The set method should correctly set a supported KeywordValue to a CSS style property of an HTML element', function() {
-    var inlineStyleMap = this.element.styleMap();
-    var keyword = new KeywordValue('auto');
-    inlineStyleMap.set('height', keyword);
-
-    assert.strictEqual(this.element.style['height'], keyword.cssString);
   });
 
   test('The set method should throw a TypeError if a StyleValue unsupported by the CSS style property is set', function() {
@@ -40,7 +32,7 @@ suite('Inline StylePropertyMap', function() {
     var inlineStyleMap = this.element.styleMap();
     var keyword = new KeywordValue('lemon');
 
-    assert.throw(function() {inlineStyleMap.set('height', keyword)}, TypeError);
+    assert.throw(function() {inlineStyleMap.set('height', keyword)}, 'height does not take the keyword lemon');
   });
 
   test('The set method should throw a TypeError if a non StyleValue is inputed into the function', function() {

--- a/test/js/inline-style-property-map.js
+++ b/test/js/inline-style-property-map.js
@@ -8,7 +8,7 @@ suite('Inline StylePropertyMap', function() {
     document.body.removeChild(this.element);
   });
 
-  test('Element.styleMap method returns a StylePropertyMap object for that element', function() {
+  test('the Element.styleMap method returns a StylePropertyMap object for that element', function() {
     var inlineStyleMap = this.element.styleMap();
     assert.instanceOf(inlineStyleMap, StylePropertyMap);
   });
@@ -41,5 +41,11 @@ suite('Inline StylePropertyMap', function() {
     var keyword = new KeywordValue('lemon');
 
     assert.throw(function() {inlineStyleMap.set('height', keyword)}, TypeError);
+  });
+
+  test('The set method should throw a TypeError if a non StyleValue is inputed into the function', function() {
+    var inlineStyleMap = this.element.styleMap();
+
+    assert.throw(function() {inlineStyleMap.set('height', 4)}, TypeError);
   });
 });


### PR DESCRIPTION
The set method has been implemented for longhand CSS properties that are defined by only one StyleValue 
