### PR TITLE
PropertyDictionary: invalid CSS property names fix

### DIFF
--- a/src/property-dictionary.js
+++ b/src/property-dictionary.js
@@ -20,7 +20,7 @@
      'pitch-range': [NumberValue],
      'border-top-width': [LengthValue],
      'opacity': [NumberValue],
-     'animation-iteration-count': [NumberValue]
+     'animationIterationCount': [NumberValue]
     };
 
     this._validKeywords = {
@@ -28,7 +28,7 @@
       'pitch-range': ['inherit'],
       'border-top-width': ['inherit'],
       'opacity': ['initial', 'inherit'],
-      'animation-iteration-count': ['infinite']
+      'animationIterationCount': ['infinite']
     };
 
     this._allowsPercentage = {
@@ -36,7 +36,7 @@
     };
 
     this._allowsListValues = {
-      'animation-iteration-count': ', '
+      'animationIterationCount': ', '
     };
   }
 

--- a/src/property-dictionary.js
+++ b/src/property-dictionary.js
@@ -99,6 +99,16 @@
     return false;
   };
 
+  PropertyDictionary.prototype
+      .throwInvalidInputError = function(property, value) {
+    if (value instanceof KeywordValue) {
+      throw new TypeError(property +
+        ' does not take the keyword ' + value.cssString);
+    }
+    throw new TypeError(property +
+      ' does not take values of type ' + value.constructor.name);
+  };
+
   var instance;
   var propertyDictionary = function() {
     if (!instance) {

--- a/src/property-dictionary.js
+++ b/src/property-dictionary.js
@@ -19,18 +19,24 @@
      'height': [LengthValue],
      'pitch-range': [NumberValue],
      'border-top-width': [LengthValue],
-     'opacity': [NumberValue]
+     'opacity': [NumberValue],
+     'animation-iteration-count': [NumberValue]
     };
 
     this._validKeywords = {
       'height': ['auto', 'inherit'],
       'pitch-range': ['inherit'],
       'border-top-width': ['inherit'],
-      'opacity': ['initial', 'inherit']
+      'opacity': ['initial', 'inherit'],
+      'animation-iteration-count': ['infinite']
     };
 
     this._allowsPercentage = {
       'height': true
+    };
+
+    this._allowsListValues = {
+      'animation-iteration-count': ', '
     };
   }
 

--- a/src/property-dictionary.js
+++ b/src/property-dictionary.js
@@ -44,6 +44,17 @@
     return (this._validProperties.hasOwnProperty(property));
   };
 
+  PropertyDictionary.prototype.isListValuedProperty = function(property) {
+    return (this._allowsListValues.hasOwnProperty(property));
+  };
+
+  PropertyDictionary.prototype.getListValueSeparator = function(property) {
+    if (this.isListValuedProperty(property)) {
+      return this._allowsListValues[property];
+    }
+    throw new TypeError(property + ' does not support lists of styleValues');
+  };
+
   PropertyDictionary.prototype.
       _lengthValueHasPercentage = function(lengthValue) {
     if (!(lengthValue instanceof LengthValue)) {

--- a/src/property-dictionary.js
+++ b/src/property-dictionary.js
@@ -18,13 +18,15 @@
     this._validProperties = {
      'height': [LengthValue],
      'pitch-range': [NumberValue],
-     'border-top-width': [LengthValue]
+     'border-top-width': [LengthValue],
+     'opacity': [NumberValue]
     };
 
     this._validKeywords = {
       'height': ['auto', 'inherit'],
       'pitch-range': ['inherit'],
-      'border-top-width': ['inherit']
+      'border-top-width': ['inherit'],
+      'opacity': ['initial', 'inherit']
     };
 
     this._allowsPercentage = {

--- a/src/property-dictionary.js
+++ b/src/property-dictionary.js
@@ -17,22 +17,23 @@
   function PropertyDictionary() {
     this._validProperties = {
      'height': [LengthValue],
-     'pitch-range': [NumberValue],
-     'border-top-width': [LengthValue],
+     'lineHeight': [NumberValue, LengthValue],
+     'borderTopWidth': [LengthValue],
      'opacity': [NumberValue],
      'animationIterationCount': [NumberValue]
     };
 
     this._validKeywords = {
       'height': ['auto', 'inherit'],
-      'pitch-range': ['inherit'],
-      'border-top-width': ['inherit'],
+      'lineHeight': ['inherit', ''],
+      'borderTopWidth': ['inherit'],
       'opacity': ['initial', 'inherit'],
       'animationIterationCount': ['infinite']
     };
 
     this._allowsPercentage = {
-      'height': true
+      'height': true,
+      'lineHeight': true
     };
 
     this._allowsListValues = {
@@ -55,8 +56,8 @@
     throw new TypeError(property + ' does not support lists of styleValues');
   };
 
-  PropertyDictionary.prototype.
-      _lengthValueHasPercentage = function(lengthValue) {
+  PropertyDictionary.prototype
+      ._lengthValueHasPercentage = function(lengthValue) {
     if (!(lengthValue instanceof LengthValue)) {
       throw new TypeError(
         'The input to _lengthValueHasPercentage must be a LengthValue');
@@ -69,8 +70,8 @@
     return (lengthValue.type == 'percent');
   };
 
-  PropertyDictionary.prototype.
-      _isValidKeyword = function(property, styleValueString) {
+  PropertyDictionary.prototype
+      ._isValidKeyword = function(property, styleValueString) {
     return this._validKeywords[property].indexOf(styleValueString) > -1;
   };
 

--- a/src/style-property-map.js
+++ b/src/style-property-map.js
@@ -56,7 +56,7 @@
       throw new TypeError(property + ' is not a supported CSS property');
     }
 
-    this._styleObject[property] = "";
+    this._styleObject[property] = '';
   };
 
   StylePropertyMap.prototype.has = function(property) {
@@ -65,7 +65,7 @@
       throw new TypeError(property + ' is not a supported CSS property');
     }
 
-    if(!this._styleObject[property] == ""){
+    if (!this._styleObject[property] == '') {
       return true;
     }
     return false;

--- a/src/style-property-map.js
+++ b/src/style-property-map.js
@@ -36,18 +36,39 @@
     }
 
     if (!cssPropertyDictionary.isValidInput(property, value)) {
-      if (value instanceof KeywordValue) {
-        throw new TypeError(property +
-          ' does not take the keyword ' + value.cssString);
-      }
-      throw new TypeError(property +
-        ' does not take values of type ' + value.constructor.name);
+      this._throwInvalidInputError(property, value);
     }
     this._styleObject[property] = value.cssString;
   };
 
-  StylePropertyMap.prototype.append = function(property, value) {
-    throw new TypeError('Function not implemented yet');
+  StylePropertyMap.prototype.append = function(property, values) {
+    var cssPropertyDictionary = propertyDictionary();
+    if (!cssPropertyDictionary.isSupportedProperty(property)) {
+      throw new TypeError(property + ' is not a supported CSS property');
+    }
+
+    if (!cssPropertyDictionary.isListValuedProperty(property)) {
+      throw new TypeError(property +
+        ' does not support lists of styleValues' + values.constructor.name);
+    }
+
+    if (values == null) {
+      throw new TypeError('Null cannot be appended to CSS propertys');
+    }
+
+    if (!(values instanceof Array)) {
+      values = [values];
+    }
+
+    var cssAppendString = this._styleObject['animationIterationCount'];
+    var valueSeparator = cssPropertyDictionary.getListValueSeparator(property);
+    for (var i = 0; i < values.length; i++) {
+      if (!cssPropertyDictionary.isValidInput(property, values[i])) {
+        this._throwInvalidInputError(property, values[i]);
+      }
+      cssAppendString += valueSeparator + values[i].cssString;
+    }
+    return this._styleObject[property] = cssAppendString;
   };
 
   StylePropertyMap.prototype.delete = function(property) {
@@ -64,6 +85,16 @@
       throw new TypeError(property + ' is not a supported CSS property');
     }
     return !(this._styleObject[property] == '');
+  };
+
+  StylePropertyMap.prototype
+      ._throwInvalidInputError = function(property, value) {
+    if (value instanceof KeywordValue) {
+      throw new TypeError(property +
+        ' does not take the keyword ' + value.cssString);
+    }
+    throw new TypeError(property +
+      ' does not take values of type ' + value.constructor.name);
   };
 
   Element.prototype.styleMap = function() {

--- a/src/style-property-map.js
+++ b/src/style-property-map.js
@@ -48,11 +48,11 @@
     }
 
     if (!cssPropertyDictionary.isListValuedProperty(property)) {
-      throw new TypeError(property + ' does not support lists of styleValues');
+      throw new TypeError(property + ' does not support sequences of styleValues');
     }
 
     if (values == null) {
-      throw new TypeError('null cannot be appended to CSS propertys');
+      throw new TypeError('null cannot be appended to CSS properties');
     }
 
     if (!(values instanceof Array)) {

--- a/src/style-property-map.js
+++ b/src/style-property-map.js
@@ -65,6 +65,10 @@
       if (!cssPropertyDictionary.isValidInput(property, values[i])) {
         cssPropertyDictionary.throwInvalidInputError(property, values[i]);
       }
+      if (cssAppendString == '') {
+        cssAppendString += values[i].cssString;
+        continue;
+      }
       cssAppendString += valueSeparator + values[i].cssString;
     }
     return this._styleObject[property] = cssAppendString;

--- a/src/style-property-map.js
+++ b/src/style-property-map.js
@@ -59,7 +59,7 @@
       values = [values];
     }
 
-    var cssAppendString = this._styleObject['animationIterationCount'];
+    var cssAppendString = this._styleObject[property];
     var valueSeparator = cssPropertyDictionary.getListValueSeparator(property);
     for (var i = 0; i < values.length; i++) {
       if (!cssPropertyDictionary.isValidInput(property, values[i])) {

--- a/src/style-property-map.js
+++ b/src/style-property-map.js
@@ -55,7 +55,6 @@
     if (!cssPropertyDictionary.isSupportedProperty(property)) {
       throw new TypeError(property + ' is not a supported CSS property');
     }
-
     this._styleObject[property] = '';
   };
 
@@ -64,11 +63,7 @@
     if (!cssPropertyDictionary.isSupportedProperty(property)) {
       throw new TypeError(property + ' is not a supported CSS property');
     }
-
-    if (!this._styleObject[property] == '') {
-      return true;
-    }
-    return false;
+    return !(this._styleObject[property] == '');
   };
 
   Element.prototype.styleMap = function() {

--- a/src/style-property-map.js
+++ b/src/style-property-map.js
@@ -22,7 +22,7 @@
   StylePropertyMap.prototype.set = function(property, value) {
     var cssPropertyDictionary = propertyDictionary();
     if (!cssPropertyDictionary.isSupportedProperty(property)) {
-      throw new TypeError(property + 'is not a supported CSS property');
+      throw new TypeError(property + ' is not a supported CSS property');
     }
 
     if (value instanceof Array) {
@@ -51,7 +51,24 @@
   };
 
   StylePropertyMap.prototype.delete = function(property) {
-    throw new TypeError('Function not implemented yet');
+    var cssPropertyDictionary = propertyDictionary();
+    if (!cssPropertyDictionary.isSupportedProperty(property)) {
+      throw new TypeError(property + ' is not a supported CSS property');
+    }
+
+    this._styleObject[property] = "";
+  };
+
+  StylePropertyMap.prototype.has = function(property) {
+    var cssPropertyDictionary = propertyDictionary();
+    if (!cssPropertyDictionary.isSupportedProperty(property)) {
+      throw new TypeError(property + ' is not a supported CSS property');
+    }
+
+    if(!this._styleObject[property] == ""){
+      return true;
+    }
+    return false;
   };
 
   Element.prototype.styleMap = function() {

--- a/src/style-property-map.js
+++ b/src/style-property-map.js
@@ -36,7 +36,7 @@
     }
 
     if (!cssPropertyDictionary.isValidInput(property, value)) {
-      this._throwInvalidInputError(property, value);
+      cssPropertyDictionary.throwInvalidInputError(property, value);
     }
     this._styleObject[property] = value.cssString;
   };
@@ -64,7 +64,7 @@
     var valueSeparator = cssPropertyDictionary.getListValueSeparator(property);
     for (var i = 0; i < values.length; i++) {
       if (!cssPropertyDictionary.isValidInput(property, values[i])) {
-        this._throwInvalidInputError(property, values[i]);
+        cssPropertyDictionary.throwInvalidInputError(property, values[i]);
       }
       cssAppendString += valueSeparator + values[i].cssString;
     }
@@ -85,16 +85,6 @@
       throw new TypeError(property + ' is not a supported CSS property');
     }
     return !(this._styleObject[property] == '');
-  };
-
-  StylePropertyMap.prototype
-      ._throwInvalidInputError = function(property, value) {
-    if (value instanceof KeywordValue) {
-      throw new TypeError(property +
-        ' does not take the keyword ' + value.cssString);
-    }
-    throw new TypeError(property +
-      ' does not take values of type ' + value.constructor.name);
   };
 
   Element.prototype.styleMap = function() {

--- a/src/style-property-map.js
+++ b/src/style-property-map.js
@@ -48,12 +48,11 @@
     }
 
     if (!cssPropertyDictionary.isListValuedProperty(property)) {
-      throw new TypeError(property +
-        ' does not support lists of styleValues' + values.constructor.name);
+      throw new TypeError(property + ' does not support lists of styleValues');
     }
 
     if (values == null) {
-      throw new TypeError('Null cannot be appended to CSS propertys');
+      throw new TypeError('null cannot be appended to CSS propertys');
     }
 
     if (!(values instanceof Array)) {

--- a/test/js/inline-style-property-map.js
+++ b/test/js/inline-style-property-map.js
@@ -100,24 +100,28 @@ suite('Inline StylePropertyMap', function() {
     var valueArray = [new NumberValue(4), new NumberValue(5), new SimpleLength(3, 'px'), new KeywordValue('infinite')];
     this.element.style['animationIterationCount'] = 'infinite, 2, 5';
 
-    assert.throw(function() {inlineStyleMap.append('animationIterationCount', valueArray)}, TypeError);
+    assert.throw(function() {inlineStyleMap.append('animationIterationCount', valueArray)}, TypeError,
+      'animationIterationCount does not take values of type SimpleLength');
   });
 
   test('The append method should throw a TypeError when an unsupported CSS property is entered', function() {
     var inlineStyleMap = this.element.styleMap();
 
-    assert.throw(function() {inlineStyleMap.append('lemon', new NumberValue(4))}, TypeError);
+    assert.throw(function() {inlineStyleMap.append('lemon', new NumberValue(4))}, TypeError,
+      'lemon is not a supported CSS property');
   });
 
   test('The append method should throw a TypeError when a CSS property that does not support list values is entered', function() {
     var inlineStyleMap = this.element.styleMap();
 
-    assert.throw(function() {inlineStyleMap.append('height', new NumberValue(4))}, TypeError);
+    assert.throw(function() {inlineStyleMap.append('height', new NumberValue(4))}, TypeError,
+      'height does not support lists of styleValues');
   });
 
   test('The append method should throw a TypeError when null is entered as the value', function() {
     var inlineStyleMap = this.element.styleMap();
 
-    assert.throw(function() {inlineStyleMap.append('height', null)}, TypeError);
+    assert.throw(function() {inlineStyleMap.append('animationIterationCount', null)}, TypeError,
+      'null cannot be appended to CSS propertys');
   });
 });

--- a/test/js/inline-style-property-map.js
+++ b/test/js/inline-style-property-map.js
@@ -19,6 +19,11 @@ suite('Inline StylePropertyMap', function() {
     inlineStyleMap.set('height', simpleLength);
 
     assert.strictEqual(this.element.style['height'], simpleLength.cssString);
+
+    var numberValue = new NumberValue(9);
+    inlineStyleMap.set('lineHeight', numberValue);
+
+    assert.strictEqual(this.element.style['lineHeight'], numberValue.cssString);
   });
 
   test('The set method should throw a TypeError if a non KeywordValue StyleValue unsupported by the CSS style property is set', function() {

--- a/test/js/inline-style-property-map.js
+++ b/test/js/inline-style-property-map.js
@@ -94,6 +94,16 @@ suite('Inline StylePropertyMap', function() {
     assert.strictEqual(this.element.style['animationIterationCount'], 'infinite, 2, 5, 4, 5, infinite');
   });
 
+  test('The append method should successfully append a list of valid CSS values to a property ' +
+      'that supports list values when the StyleValue is currently not set', function() {
+    var inlineStyleMap = this.element.styleMap();
+    var valueArray = [new NumberValue(4), new NumberValue(5), new KeywordValue('infinite')];
+    this.element.style['animationIterationCount'] = '';
+    inlineStyleMap.append('animationIterationCount', valueArray);
+
+    assert.strictEqual(this.element.style['animationIterationCount'], '4, 5, infinite');
+  });
+
   test('The append method should throw a TypeError if any index in the values array is not supported by ' +
     'the property', function() {
     var inlineStyleMap = this.element.styleMap();

--- a/test/js/inline-style-property-map.js
+++ b/test/js/inline-style-property-map.js
@@ -74,4 +74,50 @@ suite('Inline StylePropertyMap', function() {
 
     assert.throw(function() {inlineStyleMap.has('lemons')}, TypeError);
   });
+
+  test('The append method should successfully append a valid CSS values to a property ' +
+      'that supports list values', function() {
+    this.element.style['animationIterationCount'] = 'infinite, 2, 5'; 
+    var inlineStyleMap = this.element.styleMap();
+    inlineStyleMap.append('animationIterationCount', new NumberValue(4));
+
+    assert.strictEqual(this.element.style['animationIterationCount'], 'infinite, 2, 5, 4');
+  });
+
+  test('The append method should successfully append a list of valid CSS values to a property ' +
+      'that supports list values', function() { 
+    var inlineStyleMap = this.element.styleMap();
+    var valueArray = [new NumberValue(4), new NumberValue(5), new KeywordValue('infinite')];
+    this.element.style['animationIterationCount'] = 'infinite, 2, 5';
+    inlineStyleMap.append('animationIterationCount', valueArray);
+
+    assert.strictEqual(this.element.style['animationIterationCount'], 'infinite, 2, 5, 4, 5, infinite');
+  });
+
+  test('The append method should throw a TypeError if any index in the values array is not supported by ' +
+    'the property', function() { 
+    var inlineStyleMap = this.element.styleMap();
+    var valueArray = [new NumberValue(4), new NumberValue(5), new SimpleLength(3, 'px'), new KeywordValue('infinite')];
+    this.element.style['animationIterationCount'] = 'infinite, 2, 5';
+
+    assert.throw(function() {inlineStyleMap.append('animationIterationCount', valueArray)}, TypeError);
+  });
+
+  test('The append method should throw a TypeError when an unsupported CSS property is entered', function() {
+    var inlineStyleMap = this.element.styleMap();
+
+    assert.throw(function() {inlineStyleMap.append('lemon', new NumberValue(4))}, TypeError);
+  });
+
+  test('The append method should throw a TypeError when a CSS property that does not support list values is entered', function() {
+    var inlineStyleMap = this.element.styleMap();
+
+    assert.throw(function() {inlineStyleMap.append('height', new NumberValue(4))}, TypeError);
+  });
+
+  test('The append method should throw a TypeError when null is entered as the value', function() {
+    var inlineStyleMap = this.element.styleMap();
+
+    assert.throw(function() {inlineStyleMap.append('height', null)}, TypeError);
+  });
 });

--- a/test/js/inline-style-property-map.js
+++ b/test/js/inline-style-property-map.js
@@ -46,4 +46,32 @@ suite('Inline StylePropertyMap', function() {
 
     assert.throw(function() {inlineStyleMap.set('lemons', new SimpleLength(3, 'px'))}, TypeError);
   });
+
+  test('The delete method removes any set StyleValue from a valid CSS style property', function() {
+    var inlineStyleMap = this.element.styleMap();
+    this.element.style.height = '10px';
+    inlineStyleMap.delete('height');
+
+    assert.strictEqual(this.element.style['height'], '');
+  });
+
+  test('The delete method should throw a TypeError if an unsupported property is inputed into the function', function() {
+    var inlineStyleMap = this.element.styleMap();
+
+    assert.throw(function() {inlineStyleMap.delete('lemons')}, TypeError);
+  });
+
+  test('The has method will return true if a valid CSS property input has a set value' +
+    'and false if it is not set', function() {
+    var inlineStyleMap = this.element.styleMap();
+
+    assert.isTrue(inlineStyleMap.has('opacity'));
+    assert.isFalse(inlineStyleMap.has('height'));
+  });
+
+  test('The has method should throw a TypeError if an unsupported property is inputed into the function', function() {
+    var inlineStyleMap = this.element.styleMap();
+
+    assert.throw(function() {inlineStyleMap.has('lemons')}, TypeError);
+  });
 });

--- a/test/js/inline-style-property-map.js
+++ b/test/js/inline-style-property-map.js
@@ -47,7 +47,7 @@ suite('Inline StylePropertyMap', function() {
     assert.throw(function() {inlineStyleMap.set('lemons', new SimpleLength(3, 'px'))}, TypeError);
   });
 
-  test('The delete method removes any set StyleValue from a valid CSS style property', function() {
+  test('The delete method removes any StyleValue set to the CSS style property inputed', function() {
     var inlineStyleMap = this.element.styleMap();
     this.element.style.height = '10px';
     inlineStyleMap.delete('height');
@@ -55,21 +55,21 @@ suite('Inline StylePropertyMap', function() {
     assert.strictEqual(this.element.style['height'], '');
   });
 
-  test('The delete method should throw a TypeError if an unsupported property is inputed into the function', function() {
+  test('The delete method should throw a TypeError if an unsupported property given as input', function() {
     var inlineStyleMap = this.element.styleMap();
 
     assert.throw(function() {inlineStyleMap.delete('lemons')}, TypeError);
   });
 
-  test('The has method will return true if a valid CSS property input has a set value' +
-    'and false if it is not set', function() {
+  test('The has method will return true if the valid CSS property input has been set to a value' +
+    'and false if it has not been set to a value', function() {
     var inlineStyleMap = this.element.styleMap();
 
     assert.isTrue(inlineStyleMap.has('opacity'));
     assert.isFalse(inlineStyleMap.has('height'));
   });
 
-  test('The has method should throw a TypeError if an unsupported property is inputed into the function', function() {
+  test('The has method should throw a TypeError if an unsupported property is given as input', function() {
     var inlineStyleMap = this.element.styleMap();
 
     assert.throw(function() {inlineStyleMap.has('lemons')}, TypeError);

--- a/test/js/inline-style-property-map.js
+++ b/test/js/inline-style-property-map.js
@@ -75,8 +75,8 @@ suite('Inline StylePropertyMap', function() {
     assert.throw(function() {inlineStyleMap.has('lemons')}, TypeError);
   });
 
-  test('The append method should successfully append a valid CSS value to a property ' +
-      'that supports list values', function() {
+  test('The append method should successfully append a supported StyleValue to a property ' +
+      'that supports sequences of StyleValues', function() {
     this.element.style['animationIterationCount'] = 'infinite, 2, 5';
     var inlineStyleMap = this.element.styleMap();
     inlineStyleMap.append('animationIterationCount', new NumberValue(4));
@@ -84,33 +84,33 @@ suite('Inline StylePropertyMap', function() {
     assert.strictEqual(this.element.style['animationIterationCount'], 'infinite, 2, 5, 4');
   });
 
-  test('The append method should successfully append a list of valid CSS values to a property ' +
-      'that supports list values', function() {
+  test('The append method should successfully append a sequence of StyleValues to a property ' +
+      'that supports sequences of StyleValues', function() {
     var inlineStyleMap = this.element.styleMap();
-    var valueArray = [new NumberValue(4), new NumberValue(5), new KeywordValue('infinite')];
+    var valueSequence = [new NumberValue(4), new NumberValue(5), new KeywordValue('infinite')];
     this.element.style['animationIterationCount'] = 'infinite, 2, 5';
-    inlineStyleMap.append('animationIterationCount', valueArray);
+    inlineStyleMap.append('animationIterationCount', valueSequence);
 
     assert.strictEqual(this.element.style['animationIterationCount'], 'infinite, 2, 5, 4, 5, infinite');
   });
 
-  test('The append method should successfully append a list of valid CSS values to a property ' +
-      'that supports list values when the StyleValue is currently not set', function() {
+  test('The append method should successfully append a sequence of StyleValues even when the CSS property ' +
+    'is not currently set', function() {
     var inlineStyleMap = this.element.styleMap();
-    var valueArray = [new NumberValue(4), new NumberValue(5), new KeywordValue('infinite')];
+    var valueSequence = [new NumberValue(4), new NumberValue(5), new KeywordValue('infinite')];
     this.element.style['animationIterationCount'] = '';
-    inlineStyleMap.append('animationIterationCount', valueArray);
+    inlineStyleMap.append('animationIterationCount', valueSequence);
 
     assert.strictEqual(this.element.style['animationIterationCount'], '4, 5, infinite');
   });
 
-  test('The append method should throw a TypeError if any index in the values array is not supported by ' +
-    'the property', function() {
+  test('The append method should throw a TypeError if the StyleValue at any index in the values array ' +
+    'is not supported by the property', function() {
     var inlineStyleMap = this.element.styleMap();
-    var valueArray = [new NumberValue(4), new NumberValue(5), new SimpleLength(3, 'px'), new KeywordValue('infinite')];
+    var valueSequence = [new NumberValue(4), new NumberValue(5), new SimpleLength(3, 'px'), new KeywordValue('infinite')];
     this.element.style['animationIterationCount'] = 'infinite, 2, 5';
 
-    assert.throw(function() {inlineStyleMap.append('animationIterationCount', valueArray)}, TypeError,
+    assert.throw(function() {inlineStyleMap.append('animationIterationCount', valueSequence)}, TypeError,
       'animationIterationCount does not take values of type SimpleLength');
   });
 
@@ -132,6 +132,6 @@ suite('Inline StylePropertyMap', function() {
     var inlineStyleMap = this.element.styleMap();
 
     assert.throw(function() {inlineStyleMap.append('animationIterationCount', null)}, TypeError,
-      'null cannot be appended to CSS propertys');
+      'null cannot be appended to CSS properties');
   });
 });

--- a/test/js/inline-style-property-map.js
+++ b/test/js/inline-style-property-map.js
@@ -125,7 +125,7 @@ suite('Inline StylePropertyMap', function() {
     var inlineStyleMap = this.element.styleMap();
 
     assert.throw(function() {inlineStyleMap.append('height', new NumberValue(4))}, TypeError,
-      'height does not support lists of styleValues');
+      'height does not support sequences of styleValues');
   });
 
   test('The append method should throw a TypeError when null is entered as the value', function() {

--- a/test/js/inline-style-property-map.js
+++ b/test/js/inline-style-property-map.js
@@ -75,9 +75,9 @@ suite('Inline StylePropertyMap', function() {
     assert.throw(function() {inlineStyleMap.has('lemons')}, TypeError);
   });
 
-  test('The append method should successfully append a valid CSS values to a property ' +
+  test('The append method should successfully append a valid CSS value to a property ' +
       'that supports list values', function() {
-    this.element.style['animationIterationCount'] = 'infinite, 2, 5'; 
+    this.element.style['animationIterationCount'] = 'infinite, 2, 5';
     var inlineStyleMap = this.element.styleMap();
     inlineStyleMap.append('animationIterationCount', new NumberValue(4));
 
@@ -85,7 +85,7 @@ suite('Inline StylePropertyMap', function() {
   });
 
   test('The append method should successfully append a list of valid CSS values to a property ' +
-      'that supports list values', function() { 
+      'that supports list values', function() {
     var inlineStyleMap = this.element.styleMap();
     var valueArray = [new NumberValue(4), new NumberValue(5), new KeywordValue('infinite')];
     this.element.style['animationIterationCount'] = 'infinite, 2, 5';
@@ -95,7 +95,7 @@ suite('Inline StylePropertyMap', function() {
   });
 
   test('The append method should throw a TypeError if any index in the values array is not supported by ' +
-    'the property', function() { 
+    'the property', function() {
     var inlineStyleMap = this.element.styleMap();
     var valueArray = [new NumberValue(4), new NumberValue(5), new SimpleLength(3, 'px'), new KeywordValue('infinite')];
     this.element.style['animationIterationCount'] = 'infinite, 2, 5';

--- a/test/js/inline-style-property-map.js
+++ b/test/js/inline-style-property-map.js
@@ -47,7 +47,7 @@ suite('Inline StylePropertyMap', function() {
     assert.throw(function() {inlineStyleMap.set('lemons', new SimpleLength(3, 'px'))}, TypeError);
   });
 
-  test('The delete method removes any StyleValue set to the CSS style property inputed', function() {
+  test('The delete method removes any StyleValue assigned to the CSS style property inputed', function() {
     var inlineStyleMap = this.element.styleMap();
     this.element.style.height = '10px';
     inlineStyleMap.delete('height');
@@ -55,14 +55,14 @@ suite('Inline StylePropertyMap', function() {
     assert.strictEqual(this.element.style['height'], '');
   });
 
-  test('The delete method should throw a TypeError if an unsupported property given as input', function() {
+  test('The delete method should throw a TypeError if an unsupported property is given as input', function() {
     var inlineStyleMap = this.element.styleMap();
 
     assert.throw(function() {inlineStyleMap.delete('lemons')}, TypeError);
   });
 
-  test('The has method will return true if the valid CSS property input has been set to a value' +
-    'and false if it has not been set to a value', function() {
+  test('The has method will return true if the valid CSS property input has been assigned a value' +
+    'or false if it has not been assigned a value', function() {
     var inlineStyleMap = this.element.styleMap();
 
     assert.isTrue(inlineStyleMap.has('opacity'));

--- a/test/js/property-dictionary.js
+++ b/test/js/property-dictionary.js
@@ -48,4 +48,21 @@ suite('PropertyDictionary', function() {
       'that is not accepted by the CSS property', function() {
     assert.isFalse(cssPropertyDictionary.isValidInput('height', new KeywordValue('unset')));
   });
+
+  test('the isListValuedProperty method should return true if the property accepts list values' +
+      'and false if it does not', function() {
+    assert.isTrue(cssPropertyDictionary.isListValuedProperty('animation-iteration-count'));
+    assert.isFalse(cssPropertyDictionary.isListValuedProperty('height'));
+  });
+
+  test('The getListValueSeparator method should return the string used to separate a list of StyleValue strings' +
+      'for a given property', function() {
+
+    assert.strictEqual(cssPropertyDictionary.getListValueSeparator('animation-iteration-count'), ', ');
+  });
+
+  test('The getListValueSeparator method should throw a TypeError if the property entered does not support list values', function() {
+
+    assert.throw(function () {cssPropertyDictionary.getListValueSeparator('height')}, TypeError);
+  });
 });

--- a/test/js/property-dictionary.js
+++ b/test/js/property-dictionary.js
@@ -51,14 +51,14 @@ suite('PropertyDictionary', function() {
 
   test('the isListValuedProperty method should return true if the property accepts list values' +
       'and false if it does not', function() {
-    assert.isTrue(cssPropertyDictionary.isListValuedProperty('animation-iteration-count'));
+    assert.isTrue(cssPropertyDictionary.isListValuedProperty('animationIterationCount'));
     assert.isFalse(cssPropertyDictionary.isListValuedProperty('height'));
   });
 
   test('The getListValueSeparator method should return the string used to separate a list of StyleValue strings' +
       'for a given property', function() {
 
-    assert.strictEqual(cssPropertyDictionary.getListValueSeparator('animation-iteration-count'), ', ');
+    assert.strictEqual(cssPropertyDictionary.getListValueSeparator('animationIterationCount'), ', ');
   });
 
   test('The getListValueSeparator method should throw a TypeError if the property entered does not support list values', function() {

--- a/test/js/property-dictionary.js
+++ b/test/js/property-dictionary.js
@@ -22,7 +22,7 @@ suite('PropertyDictionary', function() {
 
   test('The isValidInput method should return true if the property can accept the style value entered', function() {
     assert.isTrue(cssPropertyDictionary.isValidInput('height', new SimpleLength(9.2, 'px')));
-    assert.isTrue(cssPropertyDictionary.isValidInput('pitch-range', new NumberValue(5)));
+    assert.isTrue(cssPropertyDictionary.isValidInput('lineHeight', new NumberValue(5)));
   });
 
   test('The isValidInput method should return false if the property can\'t accept the style value entered' , function() {
@@ -36,7 +36,7 @@ suite('PropertyDictionary', function() {
 
   test('The isValidInput method should return false when a percentage type LengthValue is given as input' +
       'with a CSS property that cannot accept percentage types', function() {
-    assert.isFalse(cssPropertyDictionary.isValidInput('border-top-width', new CalcLength({percent: 10})));
+    assert.isFalse(cssPropertyDictionary.isValidInput('borderTopWidth', new CalcLength({percent: 10})));
   });
 
   test('The isValidInput method should return true when a KeywordValue object contains a keyword' +
@@ -63,6 +63,6 @@ suite('PropertyDictionary', function() {
 
   test('The getListValueSeparator method should throw a TypeError if the property entered does not support list values', function() {
 
-    assert.throw(function () {cssPropertyDictionary.getListValueSeparator('height')}, TypeError);
+    assert.throw(function() {cssPropertyDictionary.getListValueSeparator('height')}, TypeError);
   });
 });


### PR DESCRIPTION
Fixes PropertyDictionary class properties as some were written using the names used when setting the values in CSS style sheets not javascript 
