### PR TITLE
Copy constructors

### DIFF
--- a/src/length-value.js
+++ b/src/length-value.js
@@ -14,7 +14,19 @@
 
 (function(internal, testing) {
 
-  function LengthValue() {}
+  // Constructor (LengthValue)
+  function LengthValue(value) {
+    if (!(value instanceof LengthValue)) {
+      throw new TypeError('Value in the LengthValue constructor must be a ' +
+          'LengthValue.');
+    }
+
+    if (value instanceof SimpleLength) {
+      return new SimpleLength(value);
+    } else {
+      return new CalcLength(value);
+    }
+  }
   internal.inherit(LengthValue, internal.StyleValue);
 
   // The different possible length types.

--- a/src/perspective.js
+++ b/src/perspective.js
@@ -27,8 +27,7 @@
       throw new TypeError('Perspective length must be strictly positive.');
     }
 
-    // TODO: Copy the LengthValue given when copy constructors are implemented.
-    this.length = length;
+    this.length = new SimpleLength(length);
     this._matrix = this._computeMatrix();
     this.cssString = this._generateCssString();
   }

--- a/src/position-value.js
+++ b/src/position-value.js
@@ -26,8 +26,8 @@
       throw new TypeError('yPos is not a LengthValue object');
     }
 
-    this.x = xPos;
-    this.y = yPos;
+    this.x = new LengthValue(xPos);
+    this.y = new LengthValue(yPos);
     this.cssString = this._generateCssString();
   }
   internal.inherit(PositionValue, internal.StyleValue);

--- a/src/simple-length.js
+++ b/src/simple-length.js
@@ -16,6 +16,9 @@
 
   // TODO: SimpleLength(simpleLength), SimpleLength(cssString)
   function SimpleLength(value, type) {
+    if (value instanceof SimpleLength && arguments.length == 1) {
+      return new SimpleLength(value.value, value.type);
+    }
     if (typeof value != 'number') {
       throw new TypeError('Value of SimpleLength must be a number.');
     }

--- a/src/translation.js
+++ b/src/translation.js
@@ -28,9 +28,9 @@
       }
     }
 
-    this.x = x;
-    this.y = y;
-    this.z = (z instanceof LengthValue) ? z : null;
+    this.x = new SimpleLength(x);
+    this.y = new SimpleLength(y);
+    this.z = (z instanceof SimpleLength) ? new SimpleLength(z) : null;
 
     this._matrix = this._computeMatrix();
     this.cssString = this._generateCssString();

--- a/test/js/calc-length.js
+++ b/test/js/calc-length.js
@@ -35,6 +35,20 @@ suite('CalcLength', function() {
     assert.strictEqual(multiValue.em, 3.2);
   });
 
+  test('CalcLength constructor works correctly for (CalcLength)', function() {
+    var original;
+    var copy;
+    assert.doesNotThrow(function() {original = new CalcLength({px: 10, em: 3.2})});
+    assert.doesNotThrow(function() {copy = new CalcLength(original)});
+    assert.strictEqual(copy.px, original.px);
+    assert.strictEqual(copy.em, original.em);
+    assert.strictEqual(copy.cssString, original.cssString);
+    assert.deepEqual(copy, original);
+
+    // Ensure that the copied object is not tied to the original.
+    assert.doesNotChange(function() {original.px = 3}, copy, 'px');
+  });
+
   test('CalcLength cssString is correct for single and multi value strings', function() {
     var singleValue;
     assert.doesNotThrow(function() {singleValue = new CalcLength({px: 10})});

--- a/test/js/length-value.js
+++ b/test/js/length-value.js
@@ -12,4 +12,20 @@ suite('LengthValue', function() {
     assert.instanceOf(calcLength, LengthValue, 'A new calcLength should be an instance of LengthValue');
     assert.instanceOf(calcLength, StyleValue, 'A new calcLength should be an instance of StyleValue');
   });
+
+  test('LengthValue copy constructor returns a LengthValue', function() {
+    var simple = new SimpleLength(3, 'px');
+    var simpleCopy;
+    assert.doesNotThrow(function() {simpleCopy = new LengthValue(simple)});
+    assert.instanceOf(simpleCopy, SimpleLength,
+        'A new simpleLength should be an instanceOf SimpleLength');
+    assert.deepEqual(simpleCopy, simple);
+
+    var calc = new CalcLength({px: 10});
+    var calcCopy;
+    assert.doesNotThrow(function() {calcCopy = new LengthValue(calc)});
+    assert.instanceOf(calcCopy, CalcLength,
+        'A new calcLength should be an instanceOf CalcLength');
+    assert.deepEqual(calcCopy, calc);
+  });
 });

--- a/test/js/simple-length.js
+++ b/test/js/simple-length.js
@@ -12,13 +12,28 @@ suite('SimpleLength', function() {
     assert.throws(function() {new SimpleLength({}, 'px')});
   });
 
-  // Possible constructors: SimpleLength(SimpleLength),
-  // SimpleLength(number, type)
-  test('SimpleLength constructor works correctly for numbers', function() {
+  test('SimpleLength constructor works correctly for (number, type)',
+      function() {
     var result;
     assert.doesNotThrow(function() {result = new SimpleLength(10, 'px')});
     assert.strictEqual(result.type, 'px');
     assert.strictEqual(result.value, 10);
+  });
+
+  test('SimpleLength constructor works correctly for (SimpleLength)',
+      function() {
+    var original;
+    var copy;
+    assert.doesNotThrow(function() {original = new SimpleLength(10, 'px')});
+    assert.doesNotThrow(function() {copy = new SimpleLength(original)});
+    assert.strictEqual(copy.type, original.type);
+    assert.strictEqual(copy.value, original.value);
+    assert.strictEqual(copy.cssString, original.cssString);
+    assert.deepEqual(copy, original);
+
+    // Ensure that the copied object is not tied to the original.
+    assert.doesNotChange(function() {original.value = 15}, copy, 'value');
+    assert.doesNotChange(function() {original.type = 'em'}, copy, 'type');
   });
 
   test('SimpleLength cssString is correctly defined for different values and types', function() {


### PR DESCRIPTION
Make copy constructors for:
- SimpleLength (in the specs)
- CalcLength (already implemented, just added tests)
- LengthValue (not in the specs, but needed in PositionValue)

Use the copy constructors in objects storing LengthValues,
so that they store a copy instead.
- SimpleLength copy constructor used in: Perspective, Translation
- LengthValue copy constructor used in: PositionValue
