### PR TITLE
CalcLength CssString helper

### DIFF
--- a/src/calc-length.js
+++ b/src/calc-length.js
@@ -40,11 +40,11 @@
           'A CalcDictionary must have at least one valid length.');
     }
 
-    this.cssString = this.createCssString();
+    this.cssString = this._generateCssString();
   }
   internal.inherit(CalcLength, internal.LengthValue);
 
-  CalcLength.prototype.createCssString = function() {
+  CalcLength.prototype._generateCssString = function() {
     var result = 'calc(';
 
     var isFirst = true;


### PR DESCRIPTION
- change method name (and make internal method)
- change to '_generateCssString' to fit with the standard
  from other classes.
