### PR TITLE
Transform SimpleLength PX type check update

### DIFF
--- a/src/perspective.js
+++ b/src/perspective.js
@@ -18,8 +18,8 @@
     if (arguments.length != 1) {
       throw new TypeError('Perspective takes exactly 1 argument.');
     }
-    // TODO: Change check of 'px' when LengthValue.LengthType enum is updated.
-    if (!(length instanceof SimpleLength) || length.type != 'px') {
+    if (!(length instanceof SimpleLength) ||
+        length.type != LengthValue.LengthType.PX) {
       throw new TypeError('Unsupported Perspective length. Only SimpleLength ' +
           'instances with type \'px\' are supported.');
     }

--- a/src/translation.js
+++ b/src/translation.js
@@ -20,9 +20,8 @@
     }
 
     for (var i = 0; i < arguments.length; i++) {
-      // TODO: Change check of 'px' when LengthValue.LengthType enum is updated.
       if (!(arguments[i] instanceof SimpleLength) ||
-          arguments[i].type != 'px') {
+          arguments[i].type != LengthValue.LengthType.PX) {
         throw new TypeError('Unsupported argument for Translation. Only ' +
             'SimpleLength instances with type \'px\' are supported.');
       }


### PR DESCRIPTION
LengthValue.LengthType enum now updated.
Update checks for type PX as apropriate and remove TODO's.
