### PR TITLE
Use createElement() to load scripts

### DIFF
--- a/target-loader.js
+++ b/target-loader.js
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 (function() {
-  var scripts = document.getElementsByTagName('script');
-  var location = scripts[scripts.length - 1].src.replace(/[^\/]+$/, '');
-  typedOMTargetConfig['typed-om'].src.forEach(function(sourceFile) {
-    document.write('<script src="' + location + sourceFile + '"></script>');
+  window.typedOMTargetConfig['typed-om'].src.forEach(function(sourceFile) {
+    var s = document.createElement('script');
+    s.src = window.typedOMIncludePath + sourceFile;
+    document.head.appendChild(s);
   });
 })();

--- a/typed-om.js
+++ b/typed-om.js
@@ -13,9 +13,11 @@
 // limitations under the License.
 
 var TYPED_OM_TESTING = false;
+var typedOMIncludePath = typedOMIncludePath || '/typed-om';
 (function() {
-  var scripts = document.getElementsByTagName('script');
-  var location = scripts[scripts.length - 1].src.replace(/[^\/]+$/, '');
-  document.write('<script src="' + location + 'target-config.js"></script>');
-  document.write('<script src="' + location + 'target-loader.js"></script>');
+  ['target-config.js', 'target-loader.js'].forEach(function(sourceFile) {
+    var s = document.createElement('script');
+    s.src = typedOMIncludePath + sourceFile;
+    document.head.appendChild(s);
+  });
 })();


### PR DESCRIPTION
The current approach to loading the scripts is both inefficient and prone to breaking.
- `document.write` is notoriously slow and a generally discouraged API. We can avoid starting the HTML parser by assembling the DOM node ourselves.
- The current script relies on the `typed-om.js` include to be the very last include. It would be more common to provide a global variable to configure the import path (admittedly, still not the best way, but the only one that works without bigger changes).
- Globals should be accessed with the `window` object.
