### PR TITLE
Resolve unknown references

### DIFF
--- a/src/calc-length.js
+++ b/src/calc-length.js
@@ -21,7 +21,7 @@
     }
 
     var isEmpty = true;
-    internal.objects.foreach(internal.LengthValue.LengthType, function(type) {
+    internal.objects.foreach(LengthValue.LengthType, function(type) {
       var value = dictionary[type];
       if (value == null) {
         this[type] = null;
@@ -42,13 +42,13 @@
 
     this.cssString = this._generateCssString();
   }
-  internal.inherit(CalcLength, internal.LengthValue);
+  internal.inherit(CalcLength, LengthValue);
 
   CalcLength.prototype._generateCssString = function() {
     var result = 'calc(';
 
     var isFirst = true;
-    internal.objects.foreach(internal.LengthValue.LengthType, function(type) {
+    internal.objects.foreach(LengthValue.LengthType, function(type) {
       var value = this[type];
       if (value == null) {
         return;  // Exit callback.
@@ -61,7 +61,7 @@
         }
         value = Math.abs(value);
       }
-      result += value + internal.LengthValue.cssStringTypeRepresentation(type);
+      result += value + LengthValue.cssStringTypeRepresentation(type);
       isFirst = false;
     }, this);
 
@@ -73,7 +73,7 @@
     var calcDictionary = {};
 
     // Iterate through all length types and multiply all non null lengths.
-    internal.objects.foreach(internal.LengthValue.LengthType, function(type) {
+    internal.objects.foreach(LengthValue.LengthType, function(type) {
       if (this[type] != null) {
         calcDictionary[type] = this[type] * multiplier;
       }
@@ -103,7 +103,7 @@
     var calcDictionary = {};
 
     // Iterate through all possible length types and add their values.
-    internal.objects.foreach(internal.LengthValue.LengthType, function(type) {
+    internal.objects.foreach(LengthValue.LengthType, function(type) {
       if (this[type] == null && addedLength[type] == null) {
         calcDictionary[type] = null;
       } else if (this[type] == null) {
@@ -126,7 +126,7 @@
     var calcDictionary = {};
 
     // Iterate through all possible length types and subtract their values.
-    internal.objects.foreach(internal.LengthValue.LengthType, function(type) {
+    internal.objects.foreach(LengthValue.LengthType, function(type) {
       if (this[type] == null && subtractedLength[type] == null) {
         calcDictionary[type] = null;
       } else if (subtractedLength[type] == null) {

--- a/src/keyword-value.js
+++ b/src/keyword-value.js
@@ -21,7 +21,7 @@
     this.keywordValue = value;
     this.cssString = value;
   }
-  internal.inherit(KeywordValue, internal.StyleValue);
+  internal.inherit(KeywordValue, StyleValue);
 
   KeywordValue.parse = function(value) {
     return new KeywordValue(value);

--- a/src/length-value.js
+++ b/src/length-value.js
@@ -12,7 +12,7 @@
 //     See the License for the specific language governing permissions and
 // limitations under the License.
 
-(function(internal, testing) {
+(function(internal, scope, testing) {
 
   // Constructor (LengthValue)
   function LengthValue(value) {
@@ -27,7 +27,7 @@
       return new CalcLength(value);
     }
   }
-  internal.inherit(LengthValue, internal.StyleValue);
+  internal.inherit(LengthValue, StyleValue);
 
   // The different possible length types.
   LengthValue.LengthType = {
@@ -143,9 +143,9 @@
     throw new TypeError('Should not be reached');
   };
 
-  internal.LengthValue = LengthValue;
+  scope.LengthValue = LengthValue;
   if (TYPED_OM_TESTING) {
     testing.LengthValue = LengthValue;
   }
 
-})(typedOM.internal, typedOMTesting);
+})(typedOM.internal, window, typedOMTesting);

--- a/src/number-value.js
+++ b/src/number-value.js
@@ -21,7 +21,7 @@
     this.value = value;
     this.cssString = '' + value;
   }
-  internal.inherit(NumberValue, internal.StyleValue);
+  internal.inherit(NumberValue, StyleValue);
 
   NumberValue.parse = function(value) {
     if (internal.parsing.isNumberValueString(value)) {

--- a/src/position-value.js
+++ b/src/position-value.js
@@ -30,7 +30,7 @@
     this.y = new LengthValue(yPos);
     this.cssString = this._generateCssString();
   }
-  internal.inherit(PositionValue, internal.StyleValue);
+  internal.inherit(PositionValue, StyleValue);
 
   PositionValue.prototype._generateCssString = function() {
     return this.x.cssString + ' ' + this.y.cssString;

--- a/src/property-dictionary.js
+++ b/src/property-dictionary.js
@@ -12,7 +12,7 @@
 //     See the License for the specific language governing permissions and
 // limitations under the License.
 
-(function(internal, scope, testing) {
+(function(internal, testing) {
 
   function PropertyDictionary() {
     this._validProperties = {

--- a/src/property-dictionary.js
+++ b/src/property-dictionary.js
@@ -12,7 +12,7 @@
 //     See the License for the specific language governing permissions and
 // limitations under the License.
 
-(function(shared, scope, testing) {
+(function(internal, scope, testing) {
 
   function PropertyDictionary() {
     this._validProperties = {
@@ -124,7 +124,7 @@
     return instance;
   };
 
-  shared.propertyDictionary = propertyDictionary;
+  internal.propertyDictionary = propertyDictionary;
   if (TYPED_OM_TESTING) {
     testing.propertyDictionary = propertyDictionary;
   }

--- a/src/simple-length.js
+++ b/src/simple-length.js
@@ -22,14 +22,14 @@
     if (typeof value != 'number') {
       throw new TypeError('Value of SimpleLength must be a number.');
     }
-    if (!internal.LengthValue.isValidLengthType(type)) {
+    if (!LengthValue.isValidLengthType(type)) {
       throw new TypeError('\'' + type + '\' is not a valid type for a SimpleLength.');
     }
     this.type = type;
     this.value = value;
     this.cssString = this._generateCssString();
   }
-  internal.inherit(SimpleLength, internal.LengthValue);
+  internal.inherit(SimpleLength, LengthValue);
 
   SimpleLength.prototype.multiply = function(multiplier) {
     return new SimpleLength((this.value * multiplier), this.type);
@@ -77,7 +77,7 @@
 
   SimpleLength.prototype._generateCssString = function() {
     var cssString = this.value +
-        internal.LengthValue.cssStringTypeRepresentation(this.type);
+        LengthValue.cssStringTypeRepresentation(this.type);
     return cssString;
   };
 

--- a/src/style-property-map-readonly.js
+++ b/src/style-property-map-readonly.js
@@ -24,7 +24,7 @@
   };
 
   StylePropertyMapReadOnly.prototype.getAll = function(property) {
-    if (!propertyDictionary().isSupportedProperty(property)) {
+    if (!internal.propertyDictionary().isSupportedProperty(property)) {
       throw new TypeError(property + ' is not a supported CSS property');
     }
 

--- a/src/style-property-map.js
+++ b/src/style-property-map.js
@@ -20,7 +20,7 @@
   internal.inherit(StylePropertyMap, internal.StylePropertyMapReadOnly);
 
   StylePropertyMap.prototype.set = function(property, value) {
-    var cssPropertyDictionary = propertyDictionary();
+    var cssPropertyDictionary = internal.propertyDictionary();
     if (!cssPropertyDictionary.isSupportedProperty(property)) {
       throw new TypeError('Cannot set ' + property + ' because it is not a supported CSS property');
     }
@@ -43,7 +43,7 @@
   };
 
   StylePropertyMap.prototype.append = function(property, values) {
-    var cssPropertyDictionary = propertyDictionary();
+    var cssPropertyDictionary = internal.propertyDictionary();
     if (!cssPropertyDictionary.isSupportedProperty(property)) {
       throw new TypeError(property + ' is not a supported CSS property');
     }
@@ -76,14 +76,14 @@
   };
 
   StylePropertyMap.prototype.delete = function(property) {
-    if (!propertyDictionary().isSupportedProperty(property)) {
+    if (!internal.propertyDictionary().isSupportedProperty(property)) {
       throw new TypeError('Cannot delete ' + property + ' because it is not a supported CSS property');
     }
     this._styleObject[property] = '';
   };
 
   StylePropertyMap.prototype.has = function(property) {
-    if (!propertyDictionary().isSupportedProperty(property)) {
+    if (!internal.propertyDictionary().isSupportedProperty(property)) {
       throw new TypeError('Cannot use has method for ' + property + ' because it is not a supported CSS property');
     }
     return !!this._styleObject[property];

--- a/src/style-value.js
+++ b/src/style-value.js
@@ -14,7 +14,9 @@
 
 (function(internal, scope, testing) {
 
-  function StyleValue() {}
+  function StyleValue() {
+    throw new TypeError('StyleValue cannot be instantiated.');
+  }
 
   StyleValue.parse = function(property, cssString) {
     if (typeof property != 'string') {

--- a/src/style-value.js
+++ b/src/style-value.js
@@ -23,7 +23,7 @@
     if (typeof cssString != 'string') {
       throw new TypeError('Must parse a string');
     }
-    if (!propertyDictionary().isSupportedProperty(property)) {
+    if (!internal.propertyDictionary().isSupportedProperty(property)) {
       // TODO: How do custom properties play into this?
       throw new TypeError('Can\'t parse an unsupported property.');
     }
@@ -32,14 +32,14 @@
     var valueArray = cssString.toLowerCase().split(', ');
     var styleValueArray = [];
     var supportedStyleValues =
-        propertyDictionary().getValidStyleValuesArray(property);
+        internal.propertyDictionary().getValidStyleValuesArray(property);
 
     var styleValueObject = null;
     var successfulParse = false;
     for (var i = 0; i < valueArray.length; i++) {
       var cssStringStyleValue = valueArray[i];
       cssStringStyleValue = cssStringStyleValue.trim();
-      if (propertyDictionary().isValidKeyword(property, cssStringStyleValue)) {
+      if (internal.propertyDictionary().isValidKeyword(property, cssStringStyleValue)) {
         styleValueArray[i] = new KeywordValue(cssStringStyleValue);
         continue;
       }
@@ -68,7 +68,7 @@
     return styleValueArray;
   };
 
-  internal.StyleValue = StyleValue;
+  scope.StyleValue = StyleValue;
   if (TYPED_OM_TESTING) {
     testing.StyleValue = StyleValue;
   }

--- a/src/transform-value.js
+++ b/src/transform-value.js
@@ -35,7 +35,7 @@
     this._matrix = this._computeMatrix();
     this.cssString = this._generateCssString();
   }
-  internal.inherit(TransformValue, internal.StyleValue);
+  internal.inherit(TransformValue, StyleValue);
 
 
   TransformValue.prototype.asMatrix = function() {


### PR DESCRIPTION
Both `LengthValue` and `StyleValue` have only been attached to the `internal` object but were used here and there without the `internal` object. However, according to spec, both Types are actually exposed as they have the `parse()` methods attached to them. 

I exposed these 2 types again.
