### PR TITLE
Added support for transform css property in PropertyDictionary

### DIFF
--- a/src/property-dictionary.js
+++ b/src/property-dictionary.js
@@ -20,7 +20,8 @@
      'pitch-range': [NumberValue],
      'border-top-width': [LengthValue],
      'opacity': [NumberValue],
-     'animation-iteration-count': [NumberValue]
+     'animation-iteration-count': [NumberValue],
+     'transform': [TransformValue]
     };
 
     this._validKeywords = {
@@ -28,7 +29,8 @@
       'pitch-range': ['inherit'],
       'border-top-width': ['inherit'],
       'opacity': ['initial', 'inherit'],
-      'animation-iteration-count': ['infinite']
+      'animation-iteration-count': ['infinite'],
+      'transform': ['none', 'initial', 'inherit']
     };
 
     this._allowsPercentage = {

--- a/src/property-dictionary.js
+++ b/src/property-dictionary.js
@@ -16,20 +16,20 @@
 
   function PropertyDictionary() {
     this._validProperties = {
-     'height': [LengthValue],
-     'pitch-range': [NumberValue],
-     'border-top-width': [LengthValue],
-     'opacity': [NumberValue],
-     'animation-iteration-count': [NumberValue],
-     'transform': [TransformValue]
+      'animation-iteration-count': [NumberValue],
+      'border-top-width': [LengthValue],
+      'height': [LengthValue],
+      'opacity': [NumberValue],
+      'pitch-range': [NumberValue],
+      'transform': [TransformValue]
     };
 
     this._validKeywords = {
-      'height': ['auto', 'inherit'],
-      'pitch-range': ['inherit'],
-      'border-top-width': ['inherit'],
-      'opacity': ['initial', 'inherit'],
       'animation-iteration-count': ['infinite'],
+      'border-top-width': ['inherit'],
+      'height': ['auto', 'inherit'],
+      'opacity': ['initial', 'inherit'],
+      'pitch-range': ['inherit'],
       'transform': ['none', 'initial', 'inherit']
     };
 

--- a/src/skew.js
+++ b/src/skew.js
@@ -49,7 +49,7 @@
   };
 
   Skew.prototype._generateCssString = function() {
-    return 'skew(' + this.ax + ', ' + this.ay + ')';
+    return 'skew(' + this.ax + 'deg' + ', ' + this.ay + 'deg' + ')';
   };
 
   scope.Skew = Skew;

--- a/test/js/skew.js
+++ b/test/js/skew.js
@@ -19,7 +19,7 @@ suite('Skew', function() {
   test('Skew constructor works correctly', function() {
     var skew;
     assert.doesNotThrow(function() {skew = new Skew(30, 180)});
-    assert.strictEqual(skew.cssString, 'skew(30, 180)');
+    assert.strictEqual(skew.cssString, 'skew(30deg, 180deg)');
     assert.strictEqual(skew.ax, 30);
     assert.strictEqual(skew.ay, 180);
     assert.isTrue(skew.is2DComponent());


### PR DESCRIPTION
A related bug was also fixed when supporting transform; the cssString for Skew was incorrect as it was missing 'deg' after each number e.g. skew(2, 2) instead of skew(2deg, 2deg) this issue has been fixed.

Note: Due to limitations of the StyleValue parsing method in the polyfill the get and getAll methods in StylePropertyMapReadOnly will not work for transform and will throw an error.
