### PR TITLE
Make loader maintain script order

### DIFF
--- a/target-loader.js
+++ b/target-loader.js
@@ -13,9 +13,20 @@
 // limitations under the License.
 
 (function() {
-  window.typedOMTargetConfig['typed-om'].src.forEach(function(sourceFile) {
-    var s = document.createElement('script');
-    s.src = window.typedOMIncludePath + sourceFile;
-    document.head.appendChild(s);
-  });
+  var loadScript = function(sourceFile) {
+    return new Promise(function(resolve, reject) {
+      var s = document.createElement('script');
+      s.src = typedOMIncludePath + '/' + sourceFile;
+      s.onload = function() {
+        resolve();
+      };
+      document.head.appendChild(s);
+    });
+  };
+
+  window.typedOMTargetConfig['typed-om'].src.reduce(function(prev, cur) {
+    return prev.then(function() {
+      return loadScript(cur);
+    });
+  }, Promise.resolve());
 })();

--- a/typed-om.js
+++ b/typed-om.js
@@ -15,9 +15,19 @@
 var TYPED_OM_TESTING = false;
 var typedOMIncludePath = typedOMIncludePath || '/typed-om';
 (function() {
-  ['target-config.js', 'target-loader.js'].forEach(function(sourceFile) {
-    var s = document.createElement('script');
-    s.src = typedOMIncludePath + sourceFile;
-    document.head.appendChild(s);
-  });
+  var loadScript = function(sourceFile) {
+    return new Promise(function(resolve, reject) {
+      var s = document.createElement('script');
+      s.src = typedOMIncludePath + '/' + sourceFile;
+      s.onload = function() {
+        resolve();
+      };
+      document.head.appendChild(s);
+    });
+  };
+  ['target-config.js', 'target-loader.js'].reduce(function(prev, cur) {
+    return prev.then(function() {
+      return loadScript(cur);
+    });
+  }, Promise.resolve());
 })();


### PR DESCRIPTION
This fix makes the loader loads scripts in the order they are specified in the respective arrays, waiting for one script to finish before loading the next. It makes the entire thing pretty slow again, but this will all go away anyways if we concat all the scripts for “production” (if we ever want to got there :wink: )

r: @rjwright 
