### PR TITLE
Implemented empty constructor for TransformValue

### DIFF
--- a/src/transform-value.js
+++ b/src/transform-value.js
@@ -15,28 +15,12 @@
 (function(internal, scope) {
 
   function TransformValue(values) {
-    if (!Array.isArray(values)) {
-      throw new TypeError('TransformValue must be an array of ' +
-          'TransformComponents.');
-    } else if (values.length < 1) {
-      throw new TypeError('TransformValue must have at least 1 ' +
-          'TransformComponent.');
+    if (values === undefined) {
+      return this._createEmptyTransform();
     }
-
-    this.transformComponents = [];
-    for (var i = 0; i < values.length; i++) {
-      if (!(values[i] instanceof TransformComponent)) {
-        throw new TypeError('Argument at index ' + i + ' is not an instance ' +
-            'of \'TransformComponent\'.');
-      }
-      this.transformComponents.push(values[i]);
-    }
-
-    this._matrix = this._computeMatrix();
-    this.cssString = this._generateCssString();
+    return this._createSequenceTransform(values);
   }
   internal.inherit(TransformValue, StyleValue);
-
 
   TransformValue.prototype.asMatrix = function() {
     return this._matrix;
@@ -59,6 +43,30 @@
       return value.cssString;
     }
     return this.transformComponents.map(getCssString).join(' ');
+  };
+
+  TransformValue.prototype._createEmptyTransform = function() {
+    this._matrix = new Matrix(1, 1, 1, 1, 1, 1);
+    this.cssString = "";
+  };
+
+  TransformValue.prototype._createSequenceTransform = function(values) {
+    if (!Array.isArray(values) || values.length < 1) {
+      throw new TypeError('TransformValue must have an array ' +
+          'with at least 1 TransformComponent.');
+    }
+
+    this.transformComponents = [];
+    for (var i = 0; i < values.length; i++) {
+      if (!(values[i] instanceof TransformComponent)) {
+        throw new TypeError('Argument at index ' + i + ' is not an instance ' +
+            'of \'TransformComponent\'.');
+      }
+      this.transformComponents.push(values[i]);
+    }
+
+    this._matrix = this._computeMatrix();
+    this.cssString = this._generateCssString();
   };
 
   scope.TransformValue = TransformValue;

--- a/src/transform-value.js
+++ b/src/transform-value.js
@@ -16,44 +16,11 @@
 
   function TransformValue(values) {
     if (values === undefined) {
-      return this._createEmptyTransform();
+      values = [];
     }
-    return this._createSequenceTransform(values);
-  }
-  internal.inherit(TransformValue, StyleValue);
-
-  TransformValue.prototype.asMatrix = function() {
-    return this._matrix;
-  };
-
-  TransformValue.prototype.is2D = function() {
-    return this.asMatrix().is2DComponent();
-  };
-
-  TransformValue.prototype._computeMatrix = function() {
-    var matrix = this.transformComponents[0].asMatrix();
-    for (var i = 1; i < this.transformComponents.length; ++i) {
-      matrix = matrix.multiply(this.transformComponents[i].asMatrix());
-    }
-    return matrix;
-  };
-
-  TransformValue.prototype._generateCssString = function() {
-    function getCssString(value) {
-      return value.cssString;
-    }
-    return this.transformComponents.map(getCssString).join(' ');
-  };
-
-  TransformValue.prototype._createEmptyTransform = function() {
-    this._matrix = new Matrix(1, 1, 1, 1, 1, 1);
-    this.cssString = "";
-  };
-
-  TransformValue.prototype._createSequenceTransform = function(values) {
-    if (!Array.isArray(values) || values.length < 1) {
+    if (!Array.isArray(values)) {
       throw new TypeError('TransformValue must have an array ' +
-          'with at least 1 TransformComponent.');
+          'of TransformComponents or must be empty');
     }
 
     this.transformComponents = [];
@@ -67,6 +34,33 @@
 
     this._matrix = this._computeMatrix();
     this.cssString = this._generateCssString();
+  }
+  internal.inherit(TransformValue, StyleValue);
+
+  TransformValue.prototype.asMatrix = function() {
+    return this._matrix;
+  };
+
+  TransformValue.prototype.is2D = function() {
+    return this.asMatrix().is2DComponent();
+  };
+
+  TransformValue.prototype._computeMatrix = function() {
+    if (!this.transformComponents.length) {
+      return new Matrix(1, 0, 0, 1, 0, 0);
+    }
+    var matrix = this.transformComponents[0].asMatrix();
+    for (var i = 1; i < this.transformComponents.length; ++i) {
+      matrix = matrix.multiply(this.transformComponents[i].asMatrix());
+    }
+    return matrix;
+  };
+
+  TransformValue.prototype._generateCssString = function() {
+    function getCssString(value) {
+      return value.cssString;
+    }
+    return this.transformComponents.map(getCssString).join(' ');
   };
 
   scope.TransformValue = TransformValue;

--- a/test/js/transform-value.js
+++ b/test/js/transform-value.js
@@ -9,7 +9,7 @@ suite('TransformValue', function() {
 
   test('TransformValue constructor throws exception for invalid types',
       function() {
-    assert.throws(function() {new TransformValue()});
+    assert.throws(function() {new TransformValue(null)});
     assert.throws(function() {new TransformValue({})});
     assert.throws(function() {new TransformValue([])});
     assert.throws(function() {new TransformValue(['1', '2'])});

--- a/test/js/transform-value.js
+++ b/test/js/transform-value.js
@@ -16,8 +16,9 @@ suite('TransformValue', function() {
     assert.throws(function() {new TransformValue([new NumberValue(5)])});
   });
 
-  test('TransformValue empty constructor should create an object with ' + 
-    'the expected properties', function() {
+  test('TransformValue empty constructor creates an object with ' + 
+    'the following properties: cssString contains an empty string, asMatrix ' +
+    'returns the 2D identity matrix', function() {
     var transform = new TransformValue();
     assert.isTrue(transform.is2D());
     assert.isTrue(transform.cssString == "");

--- a/test/js/transform-value.js
+++ b/test/js/transform-value.js
@@ -17,6 +17,14 @@ suite('TransformValue', function() {
     assert.throws(function() {new TransformValue([new NumberValue(5)])});
   });
 
+  test('TransformValue empty constructor should create an object with ' + 
+    'the expected properties', function() {
+    var transform = new TransformValue();
+    assert.isTrue(transform.is2D());
+    assert.isTrue(transform.cssString == "");
+    assert.deepEqual(transform.asMatrix(), new Matrix(1, 1, 1, 1, 1, 1));
+  });
+
   test('TransformValue constructor works with 1 component', function() {
     var transform;
     var scale = new Scale(2, -1);

--- a/test/js/transform-value.js
+++ b/test/js/transform-value.js
@@ -11,7 +11,6 @@ suite('TransformValue', function() {
       function() {
     assert.throws(function() {new TransformValue(null)});
     assert.throws(function() {new TransformValue({})});
-    assert.throws(function() {new TransformValue([])});
     assert.throws(function() {new TransformValue(['1', '2'])});
     assert.throws(function() {new TransformValue([null])});
     assert.throws(function() {new TransformValue([new NumberValue(5)])});
@@ -22,7 +21,7 @@ suite('TransformValue', function() {
     var transform = new TransformValue();
     assert.isTrue(transform.is2D());
     assert.isTrue(transform.cssString == "");
-    assert.deepEqual(transform.asMatrix(), new Matrix(1, 1, 1, 1, 1, 1));
+    assert.deepEqual(transform.asMatrix(), new Matrix(1, 0, 0, 1, 0, 0));
   });
 
   test('TransformValue constructor works with 1 component', function() {


### PR DESCRIPTION
Updated and added tests to validate the behavior of the constructor.

Current behavior
-Empty constructor and empty array in constructor produce the same object
-Empty constructor asMatrix method will give the 2D identity matrix as output
-Empty constructor cssString will give an empty string as output

Note: As of now the final behavior of an empty TransformValue has not been added to the typed om spec and so may need to change when this has been better defined.
