### PR TITLE
Rename 'parse', 'fromDictionary' and 'fromValue' to 'from'

### DIFF
--- a/src/color-value.js
+++ b/src/color-value.js
@@ -42,7 +42,7 @@
   }
   internal.inherit(CSSColorValue, CSSStyleValue);
 
-  CSSColorValue.parse = function(value) {
+  CSSColorValue.from = function(value) {
     return null;
   };
 

--- a/src/keyword-value.js
+++ b/src/keyword-value.js
@@ -23,7 +23,7 @@
   }
   internal.inherit(CSSKeywordValue, CSSStyleValue);
 
-  CSSKeywordValue.parse = function(value) {
+  CSSKeywordValue.from = function(value) {
     return new CSSKeywordValue(value);
   };
 

--- a/src/length-value.js
+++ b/src/length-value.js
@@ -97,8 +97,6 @@
     }
   };
 
-  CSSLengthValue.parse = CSSLengthValue.from;
-
   CSSLengthValue.prototype.add = function(addedLength) {
     if (this instanceof CSSSimpleLength &&
         addedLength instanceof CSSSimpleLength &&

--- a/src/length-value.js
+++ b/src/length-value.js
@@ -67,15 +67,20 @@
     }
   };
 
-  CSSLengthValue.parse = function(cssString) {
-    if (typeof cssString != 'string') {
-      throw new TypeError('Must parse a length out of a string.');
+  CSSLengthValue.from = function(value, type) {
+    if (type !== undefined) {
+      return new CSSSimpleLength(value, type);
+    } else if (typeof value == 'object') {
+      return new CSSCalcLength(value);
+    }
+    if (typeof value != 'string') {
+      throw new TypeError('Must make a length out of a string, calc dictionary, or number-type pair.');
     }
     var lengthUnits = 'px|%|em|ex|ch|rem|vw|vh|vmin|vmax|cm|mm|in|pt|pc';
     var result = internal.parsing.parseDimension(
-        new RegExp(lengthUnits, 'g'), cssString);
+        new RegExp(lengthUnits, 'g'), value);
     if (!result) {
-      throw TypeError('Unable to parse length from ' + cssString);
+      throw TypeError('Unable to make length from ' + value);
     }
     if (result['%'] != undefined) {
       // Percent is a special case - We require 'percent' instead
@@ -84,20 +89,14 @@
       delete result['%'];
     }
     var keys = Object.keys(result);
-    if (internal.parsing.isCalc(cssString)) {
+    if (internal.parsing.isCalc(value)) {
       return new CSSCalcLength(result);
     } else {
       return new CSSSimpleLength(result[keys[0]], keys[0]);
     }
   };
 
-  CSSLengthValue.fromValue = function(value, type) {
-    return new CSSSimpleLength(value, type);
-  };
-
-  CSSLengthValue.fromDictionary = function(dictionary) {
-    return new CSSCalcLength(dictionary);
-  };
+  CSSLengthValue.parse = CSSLengthValue.from;
 
   CSSLengthValue.prototype.add = function(addedLength) {
     if (this instanceof CSSSimpleLength &&

--- a/src/length-value.js
+++ b/src/length-value.js
@@ -70,7 +70,8 @@
   CSSLengthValue.from = function(value, type) {
     if (type !== undefined) {
       return new CSSSimpleLength(value, type);
-    } else if (typeof value == 'object') {
+    }
+    if (typeof value == 'object') {
       return new CSSCalcLength(value);
     }
     if (typeof value != 'string') {

--- a/src/number-value.js
+++ b/src/number-value.js
@@ -23,7 +23,7 @@
   }
   internal.inherit(CSSNumberValue, CSSStyleValue);
 
-  CSSNumberValue.parse = function(value) {
+  CSSNumberValue.from = function(value) {
     if (internal.parsing.isNumberValueString(value)) {
       return new CSSNumberValue(parseFloat(value));
     }

--- a/src/style-value.js
+++ b/src/style-value.js
@@ -50,9 +50,9 @@
       successfulParse = false;
       for (var j = 0; j < supportedStyleValues.length; j++) {
         try {
-          styleValueObject = supportedStyleValues[j].parse(cssStringStyleValue);
+          styleValueObject = supportedStyleValues[j].from(cssStringStyleValue);
         } catch (e) {
-          // Ensures method does not terminate if a CSSStyleValue parse method throws an error
+          // Ensures method does not terminate if a CSSStyleValue fom method throws an error
           continue;
         }
         if (styleValueObject != null) {

--- a/test/js/keyword-value.js
+++ b/test/js/keyword-value.js
@@ -39,15 +39,15 @@ suite('CSSKeywordValue', function() {
     assert.throws(function() { new CSSKeywordValue(true); });
   });
 
-  test('parse method should create a CSSKeywordValue object with a cssString equal to the input', function() {
-    assert.strictEqual(CSSKeywordValue.parse('auto').cssString, 'auto');
+  test('from method should create a CSSKeywordValue object with a cssString equal to the input', function() {
+    assert.strictEqual(CSSKeywordValue.from('auto').cssString, 'auto');
   });
 
-  test('parse method should throw an error if its input is not a string', function() {
-    assert.throws(function() { CSSKeywordValue.parse(3) }, TypeError, 'Keyword value must be a non-empty string.');
+  test('from method should throw an error if its input is not a string', function() {
+    assert.throws(function() { CSSKeywordValue.from(3) }, TypeError, 'Keyword value must be a non-empty string.');
   });
 
-  test('parse method should throw an error if its input is an empty string', function() {
-    assert.throws(function() { CSSKeywordValue.parse('') }, TypeError, 'Keyword value must be a non-empty string.');
+  test('from method should throw an error if its input is an empty string', function() {
+    assert.throws(function() { CSSKeywordValue.from('') }, TypeError, 'Keyword value must be a non-empty string.');
   });
 });

--- a/test/js/length-value.js
+++ b/test/js/length-value.js
@@ -1,13 +1,13 @@
 suite('CSSLengthValue', function() {
-  test('fromValue returns a CSSSimpleLength which is an instance of CSSLengthValue and CSSStyleValue', function() {
-    var simpleLength = CSSLengthValue.fromValue(9.2, 'px');
+  test('from returns a CSSSimpleLength which is an instance of CSSLengthValue and CSSStyleValue', function() {
+    var simpleLength = CSSLengthValue.from(9.2, 'px');
     assert.instanceOf(simpleLength, CSSSimpleLength, 'A new simpleLength should be an instance of CSSSimpleLength');
     assert.instanceOf(simpleLength, CSSLengthValue, 'A new simpleLength should be an instance of CSSLengthValue');
     assert.instanceOf(simpleLength, CSSStyleValue, 'A new simpleLength should be an instance of CSSStyleValue');
   });
 
-  test('fromDictionary returns a CSSCalcLength which is an instance of CSSLengthValue and CSSStyleValue', function() {
-    var calcLength = CSSLengthValue.fromDictionary({px: 10});
+  test('from returns a CSSCalcLength which is an instance of CSSLengthValue and CSSStyleValue', function() {
+    var calcLength = CSSLengthValue.from({px: 10});
     assert.instanceOf(calcLength, CSSCalcLength, 'A new calcLength should be an instance of CSSCalcLength');
     assert.instanceOf(calcLength, CSSLengthValue, 'A new calcLength should be an instance of CSSLengthValue');
     assert.instanceOf(calcLength, CSSStyleValue, 'A new calcLength should be an instance of CSSStyleValue');
@@ -29,7 +29,7 @@ suite('CSSLengthValue', function() {
     assert.deepEqual(calcCopy, calc);
   });
 
-  test('CSSLengthValue.parse returns expected CSSSimpleLengths for simple strings', function() {
+  test('CSSLengthValue.from returns expected CSSSimpleLengths for simple strings', function() {
     var values = [
       {str: '0', out: new CSSSimpleLength(0, 'px')},
       {str: '1px', out: new CSSSimpleLength(1, 'px')},
@@ -57,16 +57,16 @@ suite('CSSLengthValue', function() {
       {str: '10e3px', out: new CSSSimpleLength(10e3, 'px')},
       {str: '-3.4e-2px', out: new CSSSimpleLength(-3.4e-2, 'px')},
     ];
-  
+
     for (var i = 0; i < values.length; i++) {
-      var result = CSSLengthValue.parse(values[i].str);
+      var result = CSSLengthValue.from(values[i].str);
       assert.instanceOf(result, CSSSimpleLength);
       assert.isTrue(values[i].out.equals(result),
           'Parsing ' + values[i].str + ' did not produce the expected CSSSimpleLength.');
     }
   });
 
-  test('CSSLengthValue.parse returns expected CSSCalcLengths for calc() strings.', function() {
+  test('CSSLengthValue.from returns expected CSSCalcLengths for calc() strings.', function() {
     var values = [
       {str: 'calc(10px)', out: new CSSCalcLength({px: 10})},
       {str: 'calc(-10px)', out: new CSSCalcLength({px: -10})},
@@ -87,14 +87,14 @@ suite('CSSLengthValue', function() {
       }
     ];
     for (var i = 0; i < values.length; i++) {
-      var result = CSSLengthValue.parse(values[i].str);
+      var result = CSSLengthValue.from(values[i].str);
       assert.instanceOf(result, CSSCalcLength);
       assert.isTrue(values[i].out.equals(result),
           'Parsing ' + values[i].str + ' did not produce the expected CSSCalcLength.');
     }
   });
 
-  test('CSSLengthValue.parse throws exceptions for invalid input.', function() {
+  test('CSSLengthValue.from throws exceptions for invalid input.', function() {
     var values = [
       // Invalid types.
       null, 5,
@@ -110,7 +110,7 @@ suite('CSSLengthValue', function() {
       '100', '50somethings'
     ];
     for (var i = 0; i < values.length; i++) {
-      assert.throws(function() { CSSLengthValue.parse(values[i]); }, TypeError);
+      assert.throws(function() { CSSLengthValue.from(values[i]); }, TypeError);
     }
   });
 });

--- a/test/js/number-value.js
+++ b/test/js/number-value.js
@@ -21,26 +21,26 @@ suite('CSSNumberValue', function() {
     assert.strictEqual(value.value, 10);
   });
 
-  test('parse method should return a CSSNumberValue object if string can be successfully parsed to a number', function() {
-    assert.strictEqual(CSSNumberValue.parse('12').cssString, '12');
-    assert.strictEqual(CSSNumberValue.parse('4.01').cssString, '4.01');
-    assert.strictEqual(CSSNumberValue.parse('-456.8').cssString, '-456.8');
-    assert.strictEqual(CSSNumberValue.parse('0.0').cssString, '0');
-    assert.strictEqual(CSSNumberValue.parse('+0.0').cssString, '0');
-    assert.strictEqual(CSSNumberValue.parse('-0.0').cssString, '0');
-    assert.strictEqual(CSSNumberValue.parse('.60').cssString, '0.6');
-    assert.strictEqual(CSSNumberValue.parse('10e3').cssString, '10000');
-    assert.strictEqual(CSSNumberValue.parse('-3.4e-2').cssString, '-0.034');
+  test('from method should return a CSSNumberValue object if string can be successfully parsed to a number', function() {
+    assert.strictEqual(CSSNumberValue.from('12').cssString, '12');
+    assert.strictEqual(CSSNumberValue.from('4.01').cssString, '4.01');
+    assert.strictEqual(CSSNumberValue.from('-456.8').cssString, '-456.8');
+    assert.strictEqual(CSSNumberValue.from('0.0').cssString, '0');
+    assert.strictEqual(CSSNumberValue.from('+0.0').cssString, '0');
+    assert.strictEqual(CSSNumberValue.from('-0.0').cssString, '0');
+    assert.strictEqual(CSSNumberValue.from('.60').cssString, '0.6');
+    assert.strictEqual(CSSNumberValue.from('10e3').cssString, '10000');
+    assert.strictEqual(CSSNumberValue.from('-3.4e-2').cssString, '-0.034');
   });
 
-  test('parse method should return null if string cannot be successfully parsed to a number', function() {
-    assert.strictEqual(CSSNumberValue.parse('hello, world'), null);
-    assert.strictEqual(CSSNumberValue.parse('calc(10px+3.2em) 3px'), null);
-    assert.strictEqual(CSSNumberValue.parse('3px calc(10px+3.2em)'), null);
-    assert.strictEqual(CSSNumberValue.parse('3px'), null);
-    assert.strictEqual(CSSNumberValue.parse('scale(3, -1)'), null);
-    assert.strictEqual(CSSNumberValue.parse('1e-.0'), null);
-    assert.strictEqual(CSSNumberValue.parse('9 manyRandomLemons'), null);
-    assert.strictEqual(CSSNumberValue.parse('1e4.0'), null);
+  test('from method should return null if string cannot be successfully parsed to a number', function() {
+    assert.strictEqual(CSSNumberValue.from('hello, world'), null);
+    assert.strictEqual(CSSNumberValue.from('calc(10px+3.2em) 3px'), null);
+    assert.strictEqual(CSSNumberValue.from('3px calc(10px+3.2em)'), null);
+    assert.strictEqual(CSSNumberValue.from('3px'), null);
+    assert.strictEqual(CSSNumberValue.from('scale(3, -1)'), null);
+    assert.strictEqual(CSSNumberValue.from('1e-.0'), null);
+    assert.strictEqual(CSSNumberValue.from('9 manyRandomLemons'), null);
+    assert.strictEqual(CSSNumberValue.from('1e4.0'), null);
   });
 });


### PR DESCRIPTION
In the spec this change is specific to LengthValue, but in the code some (not sure why not all) of the other StyleValue "subclasses" also implement parse, which is used by StyleValue.parse. Should I rename 'parse' to 'from' in those subclasses too?
