### PR TITLE
Update order of rotation arguments

### DIFF
--- a/src/css-rotation.js
+++ b/src/css-rotation.js
@@ -14,7 +14,7 @@
 
 (function(internal, scope) {
 
-  function CSSRotation(angle, x, y, z) {
+  function CSSRotation(x, y, z, angle) {
     if (arguments.length != 1 && arguments.length != 4) {
       throw new TypeError('CSSRotation must have 1 or 4 arguments.');
     }
@@ -25,7 +25,7 @@
       }
     }
 
-    this.angle = angle;
+    this.angle = arguments.length == 1 ? x : angle;
 
     var is2D = (arguments.length == 1);
     this.x = is2D ? null : x;

--- a/test/js/css-rotation.js
+++ b/test/js/css-rotation.js
@@ -43,7 +43,7 @@ suite('CSSRotation', function() {
 
   test('CSSRotation constructor works correctly for 4 arguments', function() {
     var rotation;
-    assert.doesNotThrow(function() {rotation = new CSSRotation(30, 1, 0.5, -2)});
+    assert.doesNotThrow(function() {rotation = new CSSRotation(1, 0.5, -2, 30)});
     assert.strictEqual(rotation.cssString, 'rotate3d(1, 0.5, -2, 30deg)');
     assert.strictEqual(rotation.angle, 30);
     assert.strictEqual(rotation.x, 1);
@@ -62,13 +62,13 @@ suite('CSSRotation', function() {
     var expected2D = new CSSMatrix(1, 0, 0, 1, 0, 0);
     assertMatrixCloseTo(rotation2D.asMatrix(), expected2D);
 
-    var rotation3D = new CSSRotation(0, 20, -5, 10);
+    var rotation3D = new CSSRotation(20, -5, 10, 0);
     var expected3D = new CSSMatrix(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);
     assertMatrixCloseTo(rotation3D.asMatrix(), expected3D);
   });
 
   test('CSSRotation matrix with x, y, and z all 0 is the identity', function() {
-    var rotation = new CSSRotation(45, 0, 0, 0);
+    var rotation = new CSSRotation(0, 0, 0, 45);
     var expectedMatrix = new CSSMatrix(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0,
         1);
     assertMatrixCloseTo(rotation.asMatrix(), expectedMatrix);
@@ -76,7 +76,7 @@ suite('CSSRotation', function() {
 
   test('CSSRotation(angle) equivalent to CSSRotation(angle, 0, 0, 1)', function() {
     var rotation2D = new CSSRotation(30);
-    var rotation3D = new CSSRotation(30, 0, 0, 1);
+    var rotation3D = new CSSRotation(0, 0, 1, 30);
     assert.isTrue(rotation2D.is2DComponent());
     assert.isFalse(rotation3D.is2DComponent());
     assertMatrixCloseTo(rotation3D.asMatrix(),
@@ -84,8 +84,8 @@ suite('CSSRotation', function() {
   });
 
   test('CSSRotation 3D is normalizing (x, y, z)', function() {
-    var rotation = new CSSRotation(30, 1, -2, 4);
-    var rotationScaled = new CSSRotation(30, 10, -20, 40);
+    var rotation = new CSSRotation(1, -2, 4, 30);
+    var rotationScaled = new CSSRotation(10, -20, 40, 30);
     assertMatrixCloseTo(rotationScaled.asMatrix(), rotation.asMatrix());
   });
 });


### PR DESCRIPTION
This makes the arguments the same order as the stringy OM for 3D rotations: rotate(x, y, z, a)

See also: 
https://github.com/w3c/css-houdini-drafts/issues/245
https://codereview.chromium.org/2088273004/
