### PR TITLE
Add support for getting unimplemented types

### DIFF
--- a/src/css-calc-length.js
+++ b/src/css-calc-length.js
@@ -14,7 +14,7 @@
 
 (function(internal, scope) {
 
-  // TODO: CSSCalcLength(cssString)
+  // TODO: CSSCalcLength(cssText)
   function CSSCalcLength(dictionary) {
     if (typeof dictionary != 'object') {
       throw new TypeError('CSSCalcLength must be passed a dictionary object');
@@ -40,7 +40,7 @@
           'A CalcDictionary must have at least one valid length.');
     }
 
-    this.cssString = this._generateCssString();
+    this.cssText = this._generateCssString();
   }
   internal.inherit(CSSCalcLength, CSSLengthValue);
 
@@ -61,7 +61,7 @@
         }
         value = Math.abs(value);
       }
-      result += value + CSSLengthValue.cssStringTypeRepresentation(type);
+      result += value + CSSLengthValue.cssTextTypeRepresentation(type);
       isFirst = false;
     }, this);
 

--- a/src/css-color-value.js
+++ b/src/css-color-value.js
@@ -38,7 +38,7 @@
     this.g = g;
     this.b = b;
     this.a = a;
-    this.cssString = this._generateCssString();
+    this.cssText = this._generateCssString();
   }
   internal.inherit(CSSColorValue, CSSStyleValue);
 
@@ -47,14 +47,14 @@
   };
 
   CSSColorValue.prototype._generateCssString = function() {
-    var cssString = this.a == 1 ? 'rgb(' : 'rgba(';
-    cssString = cssString + this.r + ',' + this.g + ',' + this.b;
+    var cssText = this.a == 1 ? 'rgb(' : 'rgba(';
+    cssText = cssText + this.r + ',' + this.g + ',' + this.b;
 
     if (this.a != 1) {
-      cssString  = cssString + ',' + this.a;
+      cssText  = cssText + ',' + this.a;
     }
-    cssString = cssString + ')'
-    return cssString;
+    cssText = cssText + ')'
+    return cssText;
   };
 
   CSSColorValue.prototype._isInt = function(value) {

--- a/src/css-keyword-value.js
+++ b/src/css-keyword-value.js
@@ -19,7 +19,7 @@
       throw new TypeError('Keyword value must be a non-empty string.');
     }
     this.keywordValue = value;
-    this.cssString = CSS.escape(value);
+    this.cssText = CSS.escape(value);
   }
   internal.inherit(CSSKeywordValue, CSSStyleValue);
 

--- a/src/css-length-value.js
+++ b/src/css-length-value.js
@@ -54,7 +54,7 @@
     });
   };
 
-  CSSLengthValue.cssStringTypeRepresentation = function(type) {
+  CSSLengthValue.cssTextTypeRepresentation = function(type) {
     if (!CSSLengthValue.isValidLengthType(type)) {
       throw new TypeError('Invalid Length Type.');
     }

--- a/src/css-matrix.js
+++ b/src/css-matrix.js
@@ -31,7 +31,7 @@
       this._matrix[index] = arguments[index];
     }
 
-    this.cssString = this._generateCssString();
+    this.cssText = this._generateCssString();
   }
   internal.inherit(CSSMatrix, internal.CSSTransformComponent);
 
@@ -112,9 +112,9 @@
   };
 
   CSSMatrix.prototype._generateCssString = function() {
-    var cssString = this.is2DComponent() ? 'matrix' : 'matrix3d';
-    cssString += '('+ this._matrix.join(', ') + ')';
-    return cssString;
+    var cssText = this.is2DComponent() ? 'matrix' : 'matrix3d';
+    cssText += '('+ this._matrix.join(', ') + ')';
+    return cssText;
   };
 
   scope.CSSMatrix = CSSMatrix;

--- a/src/css-number-value.js
+++ b/src/css-number-value.js
@@ -19,7 +19,7 @@
       throw new TypeError('Value of CSSNumberValue must be a number.');
     }
     this.value = value;
-    this.cssString = '' + value;
+    this.cssText = '' + value;
   }
   internal.inherit(CSSNumberValue, CSSStyleValue);
 

--- a/src/css-perspective.js
+++ b/src/css-perspective.js
@@ -29,7 +29,7 @@
 
     this.length = new CSSSimpleLength(length);
     this._matrix = this._computeMatrix();
-    this.cssString = this._generateCssString();
+    this.cssText = this._generateCssString();
   }
   internal.inherit(CSSPerspective, internal.CSSTransformComponent);
 
@@ -46,7 +46,7 @@
   };
 
   CSSPerspective.prototype._generateCssString = function() {
-    return 'perspective(' + this.length.cssString + ')';
+    return 'perspective(' + this.length.cssText + ')';
   };
 
   scope.CSSPerspective = CSSPerspective;

--- a/src/css-position-value.js
+++ b/src/css-position-value.js
@@ -28,12 +28,12 @@
 
     this.x = new CSSLengthValue(xPos);
     this.y = new CSSLengthValue(yPos);
-    this.cssString = this._generateCssString();
+    this.cssText = this._generateCssString();
   }
   internal.inherit(CSSPositionValue, CSSStyleValue);
 
   CSSPositionValue.prototype._generateCssString = function() {
-    return this.x.cssString + ' ' + this.y.cssString;
+    return this.x.cssText + ' ' + this.y.cssText;
   };
 
   scope.CSSPositionValue = CSSPositionValue;

--- a/src/css-rotation.js
+++ b/src/css-rotation.js
@@ -33,7 +33,7 @@
     this.z = is2D ? null : z;
 
     this._matrix = this._computeMatrix();
-    this.cssString = this._generateCssString();
+    this.cssText = this._generateCssString();
   }
   internal.inherit(CSSRotation, internal.CSSTransformComponent);
 
@@ -76,14 +76,14 @@
   };
 
   CSSRotation.prototype._generateCssString = function() {
-    var cssString;
+    var cssText;
     if (this.is2DComponent()) {
-      cssString = 'rotate(' + this.angle + 'deg)';
+      cssText = 'rotate(' + this.angle + 'deg)';
     } else {
-      cssString = 'rotate3d(' + this.x + ', ' + this.y + ', ' + this.z + ', ' +
+      cssText = 'rotate3d(' + this.x + ', ' + this.y + ', ' + this.z + ', ' +
           this.angle + 'deg)';
     }
-    return cssString;
+    return cssText;
   };
 
   scope.CSSRotation = CSSRotation;

--- a/src/css-scale.js
+++ b/src/css-scale.js
@@ -30,7 +30,7 @@
     this.z = (typeof z == 'number') ? z : null;
 
     this._matrix = this._computeMatrix();
-    this.cssString = this._generateCssString();
+    this.cssText = this._generateCssString();
   }
   internal.inherit(CSSScale, internal.CSSTransformComponent);
 
@@ -50,13 +50,13 @@
   };
 
   CSSScale.prototype._generateCssString = function() {
-    var cssString;
+    var cssText;
     if (this.is2DComponent()) {
-      cssString = 'scale(' + this.x + ', ' + this.y + ')';
+      cssText = 'scale(' + this.x + ', ' + this.y + ')';
     } else {
-      cssString = 'scale3d(' + this.x + ', ' + this.y + ', ' + this.z + ')';
+      cssText = 'scale3d(' + this.x + ', ' + this.y + ', ' + this.z + ')';
     }
-    return cssString;
+    return cssText;
   };
 
   scope.CSSScale = CSSScale;

--- a/src/css-simple-length.js
+++ b/src/css-simple-length.js
@@ -14,7 +14,7 @@
 
 (function(internal, scope) {
 
-  // TODO: CSSSimpleLength(simpleLength), CSSSimpleLength(cssString)
+  // TODO: CSSSimpleLength(simpleLength), CSSSimpleLength(cssText)
   function CSSSimpleLength(value, type) {
     if (value instanceof CSSSimpleLength && arguments.length == 1) {
       return new CSSSimpleLength(value.value, value.type);
@@ -27,7 +27,7 @@
     }
     this.type = type;
     this.value = value;
-    this.cssString = this._generateCssString();
+    this.cssText = this._generateCssString();
   }
   internal.inherit(CSSSimpleLength, CSSLengthValue);
 
@@ -76,9 +76,9 @@
   };
 
   CSSSimpleLength.prototype._generateCssString = function() {
-    var cssString = this.value +
-        CSSLengthValue.cssStringTypeRepresentation(this.type);
-    return cssString;
+    var cssText = this.value +
+        CSSLengthValue.cssTextTypeRepresentation(this.type);
+    return cssText;
   };
 
   scope.CSSSimpleLength = CSSSimpleLength;

--- a/src/css-skew.js
+++ b/src/css-skew.js
@@ -25,7 +25,7 @@
     this.ay = ay;
 
     this._matrix = this._computeMatrix();
-    this.cssString = this._generateCssString();
+    this.cssText = this._generateCssString();
   }
   internal.inherit(CSSSkew, internal.CSSTransformComponent);
 

--- a/src/css-style-value.js
+++ b/src/css-style-value.js
@@ -14,8 +14,12 @@
 
 (function(internal, scope, testing) {
 
-  function CSSStyleValue() {
-    throw new TypeError('CSSStyleValue cannot be instantiated.');
+  function CSSStyleValue(cssText) {
+    if (!cssText) {
+      throw new TypeError('Constructing CSSStyleValues will not be available in the native implementation');
+    }
+    // CSSStyleValue constructor needs to be available for type checking, but is there a way to also warn if this is constructed?
+    this.cssText = cssText;
   }
 
   CSSStyleValue.parse = function(property, cssString) {

--- a/src/css-style-value.js
+++ b/src/css-style-value.js
@@ -18,11 +18,11 @@
     throw new TypeError('CSSStyleValue cannot be instantiated.');
   }
 
-  CSSStyleValue.parse = function(property, cssString) {
+  CSSStyleValue.parse = function(property, cssText) {
     if (typeof property != 'string') {
       throw new TypeError('Property name must be a string');
     }
-    if (typeof cssString != 'string') {
+    if (typeof cssText != 'string') {
       throw new TypeError('Must parse a string');
     }
     if (!internal.propertyDictionary().isSupportedProperty(property)) {
@@ -31,7 +31,7 @@
     }
 
     // Currently only supports sequences separated by ', '
-    var valueArray = cssString.toLowerCase().split(', ');
+    var valueArray = cssText.toLowerCase().split(', ');
     var styleValueArray = [];
     var supportedStyleValues =
         internal.propertyDictionary().getValidStyleValuesArray(property);
@@ -39,10 +39,10 @@
     var styleValueObject = null;
     var successfulParse = false;
     for (var i = 0; i < valueArray.length; i++) {
-      var cssStringStyleValue = valueArray[i];
-      cssStringStyleValue = cssStringStyleValue.trim();
-      if (internal.propertyDictionary().isValidKeyword(property, cssStringStyleValue)) {
-        styleValueArray[i] = new CSSKeywordValue(cssStringStyleValue);
+      var cssTextStyleValue = valueArray[i];
+      cssTextStyleValue = cssTextStyleValue.trim();
+      if (internal.propertyDictionary().isValidKeyword(property, cssTextStyleValue)) {
+        styleValueArray[i] = new CSSKeywordValue(cssTextStyleValue);
         continue;
       }
 
@@ -50,7 +50,7 @@
       successfulParse = false;
       for (var j = 0; j < supportedStyleValues.length; j++) {
         try {
-          styleValueObject = supportedStyleValues[j].from(cssStringStyleValue);
+          styleValueObject = supportedStyleValues[j].from(cssTextStyleValue);
         } catch (e) {
           // Ensures method does not terminate if a CSSStyleValue fom method throws an error
           continue;

--- a/src/css-transform-value.js
+++ b/src/css-transform-value.js
@@ -33,7 +33,7 @@
     }
 
     this._matrix = this._computeMatrix();
-    this.cssString = this._generateCssString();
+    this.cssText = this._generateCssString();
   }
   internal.inherit(CSSTransformValue, CSSStyleValue);
 
@@ -58,7 +58,7 @@
 
   CSSTransformValue.prototype._generateCssString = function() {
     function getCssString(value) {
-      return value.cssString;
+      return value.cssText;
     }
     return this.transformComponents.map(getCssString).join(' ');
   };

--- a/src/css-translation.js
+++ b/src/css-translation.js
@@ -32,7 +32,7 @@
     this.z = (z instanceof CSSSimpleLength) ? new CSSSimpleLength(z) : null;
 
     this._matrix = this._computeMatrix();
-    this.cssString = this._generateCssString();
+    this.cssText = this._generateCssString();
   }
   internal.inherit(CSSTranslation, internal.CSSTransformComponent);
 
@@ -55,15 +55,15 @@
   };
 
   CSSTranslation.prototype._generateCssString = function() {
-    var cssString;
+    var cssText;
     if (this.is2DComponent()) {
-      cssString = 'translate(' + this.x.cssString + ', ' + this.y.cssString +
+      cssText = 'translate(' + this.x.cssText + ', ' + this.y.cssText +
           ')';
     } else {
-      cssString = 'translate3d(' + this.x.cssString + ', ' + this.y.cssString +
-          ', ' + this.z.cssString + ')';
+      cssText = 'translate3d(' + this.x.cssText + ', ' + this.y.cssText +
+          ', ' + this.z.cssText + ')';
     }
-    return cssString;
+    return cssText;
   };
 
   scope.CSSTranslation = CSSTranslation;

--- a/src/parsing.js
+++ b/src/parsing.js
@@ -17,10 +17,10 @@
   // Extra backslashes because otherwise JS interprets them incorrectly.
   var numberValueRegexStr = '[-+]?(\\d*\\.)?\\d+(e[-+]?\\d+)?';
 
-  function isNumberValueString(cssString) {
+  function isNumberValueString(cssText) {
     // Anchor the regex to the start and end of the string..
     var numberValueRegex = new RegExp('^\\s*' + numberValueRegexStr + '\\s*$');
-    return numberValueRegex.test(cssString);
+    return numberValueRegex.test(cssText);
   }
 
   function isCalc(string) {

--- a/src/property-dictionary.js
+++ b/src/property-dictionary.js
@@ -112,7 +112,7 @@
       .throwInvalidInputError = function(property, value) {
     if (value instanceof CSSKeywordValue) {
       throw new TypeError(property +
-        ' does not take the keyword ' + value.cssString);
+        ' does not take the keyword ' + value.cssText);
     }
     throw new TypeError(property +
       ' does not take values of type ' + value.constructor.name);

--- a/src/style-property-map-readonly.js
+++ b/src/style-property-map-readonly.js
@@ -20,11 +20,11 @@
 
   StylePropertyMapReadOnly.prototype.get = function(property) {
     var parsed = this.getAll(property);
-    return parsed[0];
+    return parsed && parsed.length ? parsed[0] : null;
   };
 
   StylePropertyMapReadOnly.prototype.getAll = function(property) {
-    if (!internal.propertyDictionary().isSupportedProperty(property)) {
+    if (!(property in document.documentElement.style)) {
       throw new TypeError(property + ' is not a supported CSS property');
     }
 
@@ -33,7 +33,10 @@
       return null;
     }
 
-    return parsed = CSSStyleValue.parse(property, propertyString);
+    if (internal.propertyDictionary().isSupportedProperty(property)) {
+      return CSSStyleValue.parse(property, propertyString);
+    }
+    return [new CSSStyleValue(propertyString)];
   };
 
   StylePropertyMapReadOnly.prototype.getProperties = function() {

--- a/src/style-property-map.js
+++ b/src/style-property-map.js
@@ -39,7 +39,7 @@
     if (!cssPropertyDictionary.isValidInput(property, value)) {
       cssPropertyDictionary.throwInvalidInputError(property, value);
     }
-    this._styleObject[property] = value.cssString;
+    this._styleObject[property] = value.cssText;
   };
 
   StylePropertyMap.prototype.append = function(property, values) {
@@ -67,9 +67,9 @@
         cssPropertyDictionary.throwInvalidInputError(property, values[i]);
       }
       if (cssAppendString == '') {
-        cssAppendString += values[i].cssString;
+        cssAppendString += values[i].cssText;
       } else {
-        cssAppendString += valueSeparator + values[i].cssString;
+        cssAppendString += valueSeparator + values[i].cssText;
       }
     }
     return this._styleObject[property] = cssAppendString;

--- a/test/js/computed-style-property-map.js
+++ b/test/js/computed-style-property-map.js
@@ -20,7 +20,7 @@ suite('Computed StylePropertyMap', function() {
     var propertyStyleValue = computedStyleMap.get('opacity');
 
     assert.instanceOf(propertyStyleValue, CSSNumberValue);
-    assert.strictEqual(propertyStyleValue.cssString, '0.5');
+    assert.strictEqual(propertyStyleValue.cssText, '0.5');
   });
 
   // Test disabled for now as `animation-*` properties are automatically
@@ -36,7 +36,7 @@ suite('Computed StylePropertyMap', function() {
     var propertyStyleValue = computedStyleMap.get('animation-iteration-count');
 
     assert.instanceOf(propertyStyleValue, CSSNumberValue);
-    assert.strictEqual(propertyStyleValue.cssString, '4');
+    assert.strictEqual(propertyStyleValue.cssText, '4');
   });
 
   test('getProperties returns an ordered list of properties that have been set on an element', function() {
@@ -56,9 +56,9 @@ suite('Computed StylePropertyMap', function() {
     inlineStyleMap.set('animation-iteration-count', valueArray);
     var propertyStyleValue = computedStyleMap.getAll('animation-iteration-count');
 
-    assert.strictEqual(propertyStyleValue[0].cssString, '4');
-    assert.strictEqual(propertyStyleValue[1].cssString, '5');
-    assert.strictEqual(propertyStyleValue[2].cssString, 'infinite');
+    assert.strictEqual(propertyStyleValue[0].cssText, '4');
+    assert.strictEqual(propertyStyleValue[1].cssText, '5');
+    assert.strictEqual(propertyStyleValue[2].cssText, 'infinite');
   });
 
   test('getAll method returns an array of size 1 if only a single CSSStyleValue is set on a property', function() {
@@ -66,7 +66,7 @@ suite('Computed StylePropertyMap', function() {
     var propertyStyleValue = computedStyleMap.getAll('opacity');
 
     assert.strictEqual(propertyStyleValue.length, 1);
-    assert.strictEqual(propertyStyleValue[0].cssString, '0.5');
+    assert.strictEqual(propertyStyleValue[0].cssText, '0.5');
   });
 
   test('getAll method throws a TypeError if the property is not supported', function() {

--- a/test/js/computed-style-property-map.js
+++ b/test/js/computed-style-property-map.js
@@ -54,19 +54,19 @@ suite('Computed StylePropertyMap', function() {
     var computedStyleMap = getComputedStyleMap(this.element);
     var valueArray = [new CSSNumberValue(4), new CSSNumberValue(5), new CSSKeywordValue('infinite')];
     inlineStyleMap.set('animation-iteration-count', valueArray);
-    var propertyStyleValue = computedStyleMap.getAll('animation-iteration-count');
+    var computedValues = computedStyleMap.getAll('animation-iteration-count');
 
-    assert.strictEqual(propertyStyleValue[0].cssString, '4');
-    assert.strictEqual(propertyStyleValue[1].cssString, '5');
-    assert.strictEqual(propertyStyleValue[2].cssString, 'infinite');
+    assert.strictEqual(computedValues[0].cssString, '4');
+    assert.strictEqual(computedValues[1].cssString, '5');
+    assert.strictEqual(computedValues[2].cssString, 'infinite');
   });
 
   test('getAll method returns an array of size 1 if only a single CSSStyleValue is set on a property', function() {
     var computedStyleMap = getComputedStyleMap(this.element);
-    var propertyStyleValue = computedStyleMap.getAll('opacity');
+    var computedValues = computedStyleMap.getAll('opacity');
 
-    assert.strictEqual(propertyStyleValue.length, 1);
-    assert.strictEqual(propertyStyleValue[0].cssString, '0.5');
+    assert.strictEqual(computedValues.length, 1);
+    assert.strictEqual(computedValues[0].cssString, '0.5');
   });
 
   test('getAll method throws a TypeError if the property is not supported', function() {
@@ -74,5 +74,15 @@ suite('Computed StylePropertyMap', function() {
 
     assert.throw(function() {computedStyleMap.getAll('lemon')}, TypeError,
       'lemon is not a supported CSS property');
+  });
+
+  test('getting an unsupported but valid property returns a base CSSStyleValue', function() {
+    this.element.style.animationDelay = '5s';
+    var computedStyleMap = getComputedStyleMap(this.element);
+
+    var result = computedStyleMap.get('animation-delay');
+    console.log(result);
+    assert.instanceOf(result, CSSStyleValue);
+    assert.strictEqual(result.cssText, '5s');
   });
 });

--- a/test/js/css-calc-length.js
+++ b/test/js/css-calc-length.js
@@ -42,64 +42,64 @@ suite('CSSCalcLength', function() {
     assert.doesNotThrow(function() {copy = new CSSCalcLength(original)});
     assert.strictEqual(copy.px, original.px);
     assert.strictEqual(copy.em, original.em);
-    assert.strictEqual(copy.cssString, original.cssString);
+    assert.strictEqual(copy.cssText, original.cssText);
     assert.deepEqual(copy, original);
 
     // Ensure that the copied object is not tied to the original.
     assert.doesNotChange(function() {original.px = 3}, copy, 'px');
   });
 
-  test('CSSCalcLength cssString is correct for single and multi value strings', function() {
+  test('CSSCalcLength cssText is correct for single and multi value strings', function() {
     var singleValue;
     assert.doesNotThrow(function() {singleValue = new CSSCalcLength({px: 10})});
     assert.strictEqual(singleValue.px, 10);
-    assert.strictEqual(singleValue.cssString, 'calc(10px)');
+    assert.strictEqual(singleValue.cssText, 'calc(10px)');
 
     var multiValue;
     assert.doesNotThrow(function() {multiValue = new CSSCalcLength({px: 10, em: 3.2})});
     assert.strictEqual(multiValue.px, 10);
     assert.strictEqual(multiValue.em, 3.2);
-    assert.strictEqual(multiValue.cssString, 'calc(10px + 3.2em)');
+    assert.strictEqual(multiValue.cssText, 'calc(10px + 3.2em)');
 
     var negativeValues;
     assert.doesNotThrow(function() {negativeValues = new CSSCalcLength({px: -10, em: -3.2, pt: 0})});
     assert.strictEqual(negativeValues.px, -10);
     assert.strictEqual(negativeValues.em, -3.2);
     assert.strictEqual(negativeValues.pt, 0);
-    assert.strictEqual(negativeValues.cssString, 'calc(-10px - 3.2em + 0pt)');
+    assert.strictEqual(negativeValues.cssText, 'calc(-10px - 3.2em + 0pt)');
 
     var percentValue;
     assert.doesNotThrow(function() {percentValue = new CSSCalcLength({percent: 10})});
     assert.strictEqual(percentValue.percent, 10);
-    assert.strictEqual(percentValue.cssString, 'calc(10%)');
+    assert.strictEqual(percentValue.cssText, 'calc(10%)');
   });
 
   test('Multiplication of a CSSCalcLength length produces a new CSSCalcLength object', function() {
     var calcLength = new CSSCalcLength({px: 10, em: 3.2});
     var result = calcLength.multiply(4);
 
-    assert.strictEqual(result.cssString, 'calc(40px + 12.8em)');
+    assert.strictEqual(result.cssText, 'calc(40px + 12.8em)');
   });
 
   test('Multiplication of a decimal number produces expected result', function() {
     var calcLength = new CSSCalcLength({px: 10, em: 3.2});
     var result = calcLength.multiply(0.5);
 
-    assert.strictEqual(result.cssString, 'calc(5px + 1.6em)');
+    assert.strictEqual(result.cssText, 'calc(5px + 1.6em)');
   });
 
   test('Division of a CSSCalcLength length produces a new CSSCalcLength object', function() {
     var calcLength = new CSSCalcLength({px: 10, em: 4.0});
     var result = calcLength.divide(4);
 
-    assert.strictEqual(result.cssString, 'calc(2.5px + 1em)');
+    assert.strictEqual(result.cssText, 'calc(2.5px + 1em)');
   });
 
   test('Division of a decimal number produces expected result', function() {
     var calcLength = new CSSCalcLength({px: 25, em: 3.2});
     var result = calcLength.divide(2.5);
 
-    assert.strictEqual(result.cssString, 'calc(10px + 1.28em)');
+    assert.strictEqual(result.cssText, 'calc(10px + 1.28em)');
   });
 
   test('Adding two CSSCalcLengths returns a new CSSCalcLength with expected values in each value type', function() {

--- a/test/js/css-color-value.js
+++ b/test/js/css-color-value.js
@@ -34,16 +34,16 @@ suite('CSSColorValue', function() {
       'a must be a number between 0 and 1.');
   });
 
-  test('cssString should return rgb(<number>,<number>,<number>) if alpha ' +
+  test('cssText should return rgb(<number>,<number>,<number>) if alpha ' +
     'is equal to 1', function() {
-    assert.strictEqual(new CSSColorValue(50, 100, 100).cssString, 'rgb(50,100,100)');
-    assert.strictEqual(new CSSColorValue(50, 100, 100, 1).cssString, 'rgb(50,100,100)');
+    assert.strictEqual(new CSSColorValue(50, 100, 100).cssText, 'rgb(50,100,100)');
+    assert.strictEqual(new CSSColorValue(50, 100, 100, 1).cssText, 'rgb(50,100,100)');
   });
 
-  test('cssString should return rgb(<number>,<number>,<number>,<number>) if alpha ' +
+  test('cssText should return rgb(<number>,<number>,<number>,<number>) if alpha ' +
     'is not equal to 1', function() {
     var color = new CSSColorValue(50, 100, 100, 0.2);
 
-    assert.strictEqual(color.cssString, 'rgba(50,100,100,0.2)');
+    assert.strictEqual(color.cssText, 'rgba(50,100,100,0.2)');
   });
 });

--- a/test/js/css-keyword-value.js
+++ b/test/js/css-keyword-value.js
@@ -7,20 +7,20 @@ suite('CSSKeywordValue', function() {
       'A new CSSKeywordValue should be an instance of CSSStyleValue');
   });
 
-  test('CSSKeywordValue.cssString and CSSKeywordValue.keywordValue are correctly ' +
+  test('CSSKeywordValue.cssText and CSSKeywordValue.keywordValue are correctly ' +
       'initialized', function() {
     var keywordValue = new CSSKeywordValue('initial');
-    var cssString = 'initial';
-    assert.strictEqual(keywordValue.keywordValue, cssString);
-    assert.strictEqual(keywordValue.cssString, cssString);
+    var cssText = 'initial';
+    assert.strictEqual(keywordValue.keywordValue, cssText);
+    assert.strictEqual(keywordValue.cssText, cssText);
   });
 
-  test('cssString returns a string with the same format as CSS.escape()', function() {
-    assert.strictEqual(new CSSKeywordValue('initial').cssString, 'initial');
-    assert.strictEqual(new CSSKeywordValue('center').cssString, 'center');
-    assert.strictEqual(new CSSKeywordValue('customLemon').cssString, 'customLemon');
-    assert.strictEqual(new CSSKeywordValue(' Hello World').cssString, CSS.escape(' Hello World'));
-    assert.strictEqual(new CSSKeywordValue('3').cssString, CSS.escape('3'));
+  test('cssText returns a string with the same format as CSS.escape()', function() {
+    assert.strictEqual(new CSSKeywordValue('initial').cssText, 'initial');
+    assert.strictEqual(new CSSKeywordValue('center').cssText, 'center');
+    assert.strictEqual(new CSSKeywordValue('customLemon').cssText, 'customLemon');
+    assert.strictEqual(new CSSKeywordValue(' Hello World').cssText, CSS.escape(' Hello World'));
+    assert.strictEqual(new CSSKeywordValue('3').cssText, CSS.escape('3'));
   });
 
   test('keywordValue returns a string equal to the string used in the constructor', function() {
@@ -39,8 +39,8 @@ suite('CSSKeywordValue', function() {
     assert.throws(function() { new CSSKeywordValue(true); });
   });
 
-  test('from method should create a CSSKeywordValue object with a cssString equal to the input', function() {
-    assert.strictEqual(CSSKeywordValue.from('auto').cssString, 'auto');
+  test('from method should create a CSSKeywordValue object with a cssText equal to the input', function() {
+    assert.strictEqual(CSSKeywordValue.from('auto').cssText, 'auto');
   });
 
   test('from method should throw an error if its input is not a string', function() {

--- a/test/js/css-matrix.js
+++ b/test/js/css-matrix.js
@@ -20,7 +20,7 @@ suite('CSSMatrix', function() {
       value = new CSSMatrix(10, 20, -0.5, 0.5, 4, 2);
     });
     assert.isTrue(value.is2DComponent());
-    assert.strictEqual(value.cssString,
+    assert.strictEqual(value.cssText,
       'matrix(10, 20, -0.5, 0.5, 4, 2)');
     assert.strictEqual(value._matrix.length, 6);
     for (var i = 0; i < value._matrix.length; i++) {
@@ -36,7 +36,7 @@ suite('CSSMatrix', function() {
     });
     assert.isFalse(value.is2DComponent());
     assert.strictEqual(value._matrix.length, 16);
-    assert.strictEqual(value.cssString,
+    assert.strictEqual(value.cssText,
       'matrix3d(10, 20, 0, 0, -0.5, 0.5, 0, 0, 0, 0, 1, 0, 4, 2, 0, 1)');
     for (var i = 0; i < value._matrix.length; i++) {
       assert.strictEqual(value._matrix[i], randomValues[i]);
@@ -53,12 +53,12 @@ suite('CSSMatrix', function() {
 
     var identity2DTo3D = identity2D.to3DComponent();
     assert.isFalse(identity2DTo3D.is2DComponent());
-    assert.strictEqual(identity2DTo3D.cssString, identity3D.cssString);
+    assert.strictEqual(identity2DTo3D.cssText, identity3D.cssText);
     assert.deepEqual(identity2DTo3D, identity3D);
 
     var identity3DTo3D = identity3D.to3DComponent();
     assert.isFalse(identity3DTo3D.is2DComponent());
-    assert.strictEqual(identity3DTo3D.cssString, identity3D.cssString);
+    assert.strictEqual(identity3DTo3D.cssText, identity3D.cssText);
     assert.deepEqual(identity3DTo3D, identity3D);
     assert.deepEqual(identity3DTo3D, identity2DTo3D);
   });
@@ -73,12 +73,12 @@ suite('CSSMatrix', function() {
 
     var random2DTo3D = random2D.to3DComponent();
     assert.isFalse(random2DTo3D.is2DComponent());
-    assert.strictEqual(random2DTo3D.cssString, random3D.cssString);
+    assert.strictEqual(random2DTo3D.cssText, random3D.cssText);
     assert.deepEqual(random2DTo3D, random3D);
 
     var random3DTo3D = random3D.to3DComponent();
     assert.isFalse(random3DTo3D.is2DComponent());
-    assert.strictEqual(random3DTo3D.cssString, random3D.cssString);
+    assert.strictEqual(random3DTo3D.cssText, random3D.cssText);
     assert.deepEqual(random3DTo3D, random3D);
   });
 
@@ -108,12 +108,12 @@ suite('CSSMatrix', function() {
 
     var multiply2DAnd3D = identity2D.multiply(identity3D);
     assert.isFalse(multiply2DAnd3D.is2DComponent());
-    assert.strictEqual(multiply2DAnd3D.cssString, identity3D.cssString);
+    assert.strictEqual(multiply2DAnd3D.cssText, identity3D.cssText);
     assert.deepEqual(multiply2DAnd3D, identity3D);
 
     var multiply3DAnd2D = identity3D.multiply(identity2D);
     assert.isFalse(multiply3DAnd2D.is2DComponent());
-    assert.strictEqual(multiply2DAnd3D.cssString, identity3D.cssString);
+    assert.strictEqual(multiply2DAnd3D.cssText, identity3D.cssText);
     assert.deepEqual(multiply3DAnd2D, identity3D);
   });
 
@@ -124,7 +124,7 @@ suite('CSSMatrix', function() {
 
     var result = random1.multiply(random2);
     assert.isTrue(result.is2DComponent());
-    assert.strictEqual(result.cssString, expectedResult.cssString);
+    assert.strictEqual(result.cssText, expectedResult.cssText);
     assert.deepEqual(result, expectedResult);
   });
 
@@ -141,14 +141,14 @@ suite('CSSMatrix', function() {
 
     var multiply2DAnd3D = random2D.multiply(random3D);
     assert.isFalse(multiply2DAnd3D.is2DComponent());
-    assert.strictEqual(multiply2DAnd3D.cssString,
-        expectedMultiply2DAnd3D.cssString);
+    assert.strictEqual(multiply2DAnd3D.cssText,
+        expectedMultiply2DAnd3D.cssText);
     assert.deepEqual(multiply2DAnd3D, expectedMultiply2DAnd3D);
 
     var multiply3DAnd2D = random3D.multiply(random2D);
     assert.isFalse(multiply3DAnd2D.is2DComponent());
-    assert.strictEqual(multiply3DAnd2D.cssString,
-        expectedMultiply3DAnd2D.cssString);
+    assert.strictEqual(multiply3DAnd2D.cssText,
+        expectedMultiply3DAnd2D.cssText);
     assert.deepEqual(multiply3DAnd2D, expectedMultiply3DAnd2D);
   });
 
@@ -163,7 +163,7 @@ suite('CSSMatrix', function() {
 
     var result = random1.multiply(random2);
     assert.isFalse(result.is2DComponent());
-    assert.strictEqual(result.cssString, expectedResult.cssString);
+    assert.strictEqual(result.cssText, expectedResult.cssText);
     assert.deepEqual(result, expectedResult);
   });
 });

--- a/test/js/css-number-value.js
+++ b/test/js/css-number-value.js
@@ -17,20 +17,20 @@ suite('CSSNumberValue', function() {
       'strings', function() {
     var value;
     assert.doesNotThrow(function() {value = new CSSNumberValue(10)});
-    assert.strictEqual(value.cssString, '10');
+    assert.strictEqual(value.cssText, '10');
     assert.strictEqual(value.value, 10);
   });
 
   test('from method should return a CSSNumberValue object if string can be successfully parsed to a number', function() {
-    assert.strictEqual(CSSNumberValue.from('12').cssString, '12');
-    assert.strictEqual(CSSNumberValue.from('4.01').cssString, '4.01');
-    assert.strictEqual(CSSNumberValue.from('-456.8').cssString, '-456.8');
-    assert.strictEqual(CSSNumberValue.from('0.0').cssString, '0');
-    assert.strictEqual(CSSNumberValue.from('+0.0').cssString, '0');
-    assert.strictEqual(CSSNumberValue.from('-0.0').cssString, '0');
-    assert.strictEqual(CSSNumberValue.from('.60').cssString, '0.6');
-    assert.strictEqual(CSSNumberValue.from('10e3').cssString, '10000');
-    assert.strictEqual(CSSNumberValue.from('-3.4e-2').cssString, '-0.034');
+    assert.strictEqual(CSSNumberValue.from('12').cssText, '12');
+    assert.strictEqual(CSSNumberValue.from('4.01').cssText, '4.01');
+    assert.strictEqual(CSSNumberValue.from('-456.8').cssText, '-456.8');
+    assert.strictEqual(CSSNumberValue.from('0.0').cssText, '0');
+    assert.strictEqual(CSSNumberValue.from('+0.0').cssText, '0');
+    assert.strictEqual(CSSNumberValue.from('-0.0').cssText, '0');
+    assert.strictEqual(CSSNumberValue.from('.60').cssText, '0.6');
+    assert.strictEqual(CSSNumberValue.from('10e3').cssText, '10000');
+    assert.strictEqual(CSSNumberValue.from('-3.4e-2').cssText, '-0.034');
   });
 
   test('from method should return null if string cannot be successfully parsed to a number', function() {

--- a/test/js/css-perspective.js
+++ b/test/js/css-perspective.js
@@ -31,16 +31,16 @@ suite('CSSPerspective', function() {
     var perspective;
     var length = new CSSSimpleLength(10, 'px');
     assert.doesNotThrow(function() {perspective = new CSSPerspective(length)});
-    assert.strictEqual(perspective.cssString,
-        'perspective(' + length.cssString + ')');
+    assert.strictEqual(perspective.cssText,
+        'perspective(' + length.cssText + ')');
     assert.strictEqual(perspective.length.value, 10);
     assert.deepEqual(perspective.length, length);
     assert.isFalse(perspective.is2DComponent());
 
     var expectedMatrix = new CSSMatrix(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, -0.1, 0, 0,
         0, 1);
-    assert.strictEqual(perspective.asMatrix().cssString,
-        expectedMatrix.cssString);
+    assert.strictEqual(perspective.asMatrix().cssText,
+        expectedMatrix.cssText);
     assert.deepEqual(perspective.asMatrix(), expectedMatrix);
   });
 });

--- a/test/js/css-position-value.js
+++ b/test/js/css-position-value.js
@@ -9,6 +9,6 @@ suite('CSSPositionValue', function() {
     var lengthValue_2 = new CSSSimpleLength(3, 'px');
     var positionValue = new CSSPositionValue(lengthValue_1, lengthValue_2);
 
-    assert.strictEqual(positionValue.cssString, 'calc(10px + 3.2em) 3px');
+    assert.strictEqual(positionValue.cssText, 'calc(10px + 3.2em) 3px');
   });
 });

--- a/test/js/css-rotation.js
+++ b/test/js/css-rotation.js
@@ -29,7 +29,7 @@ suite('CSSRotation', function() {
   test('CSSRotation constructor works correctly for 1 argument', function() {
     var rotation;
     assert.doesNotThrow(function() {rotation = new CSSRotation(60)});
-    assert.strictEqual(rotation.cssString, 'rotate(60deg)');
+    assert.strictEqual(rotation.cssText, 'rotate(60deg)');
     assert.strictEqual(rotation.angle, 60);
     assert.isNull(rotation.x);
     assert.isNull(rotation.y);
@@ -44,7 +44,7 @@ suite('CSSRotation', function() {
   test('CSSRotation constructor works correctly for 4 arguments', function() {
     var rotation;
     assert.doesNotThrow(function() {rotation = new CSSRotation(30, 1, 0.5, -2)});
-    assert.strictEqual(rotation.cssString, 'rotate3d(1, 0.5, -2, 30deg)');
+    assert.strictEqual(rotation.cssText, 'rotate3d(1, 0.5, -2, 30deg)');
     assert.strictEqual(rotation.angle, 30);
     assert.strictEqual(rotation.x, 1);
     assert.strictEqual(rotation.y, 0.5);

--- a/test/js/css-scale.js
+++ b/test/js/css-scale.js
@@ -19,21 +19,21 @@ suite('CSSScale', function() {
   test('CSSScale constructor works correctly for 2 arguments', function() {
     var scale;
     assert.doesNotThrow(function() {scale = new CSSScale(3, -1)});
-    assert.strictEqual(scale.cssString, 'scale(3, -1)');
+    assert.strictEqual(scale.cssText, 'scale(3, -1)');
     assert.strictEqual(scale.x, 3);
     assert.strictEqual(scale.y, -1);
     assert.isNull(scale.z);
     assert.isTrue(scale.is2DComponent());
 
     var expectedMatrix = new CSSMatrix(3, 0, 0, -1, 0, 0);
-    assert.strictEqual(scale.asMatrix().cssString, expectedMatrix.cssString);
+    assert.strictEqual(scale.asMatrix().cssText, expectedMatrix.cssText);
     assert.deepEqual(scale.asMatrix(), expectedMatrix);
   });
 
   test('CSSScale constructor works correctly for 3 arguments', function() {
     var scale;
     assert.doesNotThrow(function() {scale = new CSSScale(3, 0.5, -4)});
-    assert.strictEqual(scale.cssString, 'scale3d(3, 0.5, -4)');
+    assert.strictEqual(scale.cssText, 'scale3d(3, 0.5, -4)');
     assert.strictEqual(scale.x, 3);
     assert.strictEqual(scale.y, 0.5);
     assert.strictEqual(scale.z, -4);
@@ -41,7 +41,7 @@ suite('CSSScale', function() {
 
     var expectedMatrix = new CSSMatrix(3, 0, 0, 0, 0, 0.5, 0, 0, 0, 0, -4, 0, 0, 0,
         0, 1);
-    assert.strictEqual(scale.asMatrix().cssString, expectedMatrix.cssString);
+    assert.strictEqual(scale.asMatrix().cssText, expectedMatrix.cssText);
     assert.deepEqual(scale.asMatrix(), expectedMatrix);
   });
 });

--- a/test/js/css-simple-length.js
+++ b/test/js/css-simple-length.js
@@ -28,7 +28,7 @@ suite('CSSSimpleLength', function() {
     assert.doesNotThrow(function() {copy = new CSSSimpleLength(original)});
     assert.strictEqual(copy.type, original.type);
     assert.strictEqual(copy.value, original.value);
-    assert.strictEqual(copy.cssString, original.cssString);
+    assert.strictEqual(copy.cssText, original.cssText);
     assert.deepEqual(copy, original);
 
     // Ensure that the copied object is not tied to the original.
@@ -36,18 +36,18 @@ suite('CSSSimpleLength', function() {
     assert.doesNotChange(function() {original.type = 'em'}, copy, 'type');
   });
 
-  test('CSSSimpleLength cssString is correctly defined for different values and types', function() {
+  test('CSSSimpleLength cssText is correctly defined for different values and types', function() {
     var pixValue;
     assert.doesNotThrow(function() {pixValue = new CSSSimpleLength(10, 'px')});
-    assert.strictEqual(pixValue.cssString, '10px');
+    assert.strictEqual(pixValue.cssText, '10px');
 
     var percentValue;
     assert.doesNotThrow(function() {percentValue = new CSSSimpleLength(10, 'percent')});
-    assert.strictEqual(percentValue.cssString, '10%');
+    assert.strictEqual(percentValue.cssText, '10%');
 
     var negativeValue;
     assert.doesNotThrow(function() {negativeValue = new CSSSimpleLength(-3.2, 'px')});
-    assert.strictEqual(negativeValue.cssString, '-3.2px');
+    assert.strictEqual(negativeValue.cssText, '-3.2px');
   });
 
   test('Multiplication of a CSSSimpleLength produces a new CSSSimpleLength object', function() {

--- a/test/js/css-skew.js
+++ b/test/js/css-skew.js
@@ -19,7 +19,7 @@ suite('CSSSkew', function() {
   test('CSSSkew constructor works correctly', function() {
     var skew;
     assert.doesNotThrow(function() {skew = new CSSSkew(30, 180)});
-    assert.strictEqual(skew.cssString, 'skew(30deg, 180deg)');
+    assert.strictEqual(skew.cssText, 'skew(30deg, 180deg)');
     assert.strictEqual(skew.ax, 30);
     assert.strictEqual(skew.ay, 180);
     assert.isTrue(skew.is2DComponent());
@@ -28,7 +28,7 @@ suite('CSSSkew', function() {
     var tanAy = CSSSkew._tanDegrees(180);
 
     var expectedMatrix = new CSSMatrix(1, tanAy, tanAx, 1, 0, 0);
-    assert.strictEqual(skew.asMatrix().cssString, expectedMatrix.cssString);
+    assert.strictEqual(skew.asMatrix().cssText, expectedMatrix.cssText);
     assert.deepEqual(skew.asMatrix(), expectedMatrix);
   });
 

--- a/test/js/css-style-value.js
+++ b/test/js/css-style-value.js
@@ -1,30 +1,30 @@
 suite('CSSStyleValue', function() {
-  test('parse successfully creates a CSSKeywordValue object if the cssString is a valid keyword for a property', function() {
+  test('parse successfully creates a CSSKeywordValue object if the cssText is a valid keyword for a property', function() {
     var keywordValueArray = CSSStyleValue.parse('height', 'auto');
 
-    assert.strictEqual(keywordValueArray[0].cssString, 'auto');
+    assert.strictEqual(keywordValueArray[0].cssText, 'auto');
   });
 
-  test('parse successfully creates a CSSLengthValue object if the cssString is a valid and the property supports lengthValues', function() {
+  test('parse successfully creates a CSSLengthValue object if the cssText is a valid and the property supports lengthValues', function() {
     var keywordValueArray = CSSStyleValue.parse('height', 'calc(10px + 3em)');
 
-    assert.strictEqual(keywordValueArray[0].cssString, 'calc(10px + 3em)');
+    assert.strictEqual(keywordValueArray[0].cssText, 'calc(10px + 3em)');
   });
 
   test('parse should be case insensitive', function() {
     var keywordValueArray = CSSStyleValue.parse('height', 'CaLc(10px + 3em)');
 
-    assert.strictEqual(keywordValueArray[0].cssString, 'calc(10px + 3em)');
+    assert.strictEqual(keywordValueArray[0].cssText, 'calc(10px + 3em)');
   });
 
-  test('parse successfully creates an array of CSSStyleValue objects if the cssString is a valid list of values ' +
+  test('parse successfully creates an array of CSSStyleValue objects if the cssText is a valid list of values ' +
     'for a property', function() {
     var keywordValueArray = CSSStyleValue.parse('animation-iteration-count', 'infinite, 4, 5, 7, 9');
 
     assert.deepEqual(keywordValueArray, [new CSSKeywordValue('infinite'), new CSSNumberValue(4), new CSSNumberValue(5), new CSSNumberValue(7), new CSSNumberValue(9)]);
   });
 
-  test('parse throws an error if either the property or the cssString is not a string', function() {
+  test('parse throws an error if either the property or the cssText is not a string', function() {
     assert.throws(function() {CSSStyleValue.parse(4, 'auto')}, TypeError, 'Property name must be a string');
     assert.throws(function() {CSSStyleValue.parse('height', 5)}, TypeError, 'Must parse a string');
   });
@@ -33,7 +33,7 @@ suite('CSSStyleValue', function() {
     assert.throws(function() {CSSStyleValue.parse('lemons', '10px')}, TypeError, 'Can\'t parse an unsupported property.');
   });
 
-  test('parse throws an error if a cssString representing a CSSStyleValue type unsupported by a property is entered', function() {
+  test('parse throws an error if a cssText representing a CSSStyleValue type unsupported by a property is entered', function() {
     assert.throws(function() {CSSStyleValue.parse('height', '10')}, TypeError, 'height has an unsupported CSSStyleValue type or Sequence value separator');
   });
 });

--- a/test/js/css-transform-value.js
+++ b/test/js/css-transform-value.js
@@ -17,11 +17,11 @@ suite('CSSTransformValue', function() {
   });
 
   test('CSSTransformValue empty constructor creates an object with ' + 
-    'the following properties: cssString contains an empty string, asMatrix ' +
+    'the following properties: cssText contains an empty string, asMatrix ' +
     'returns the 2D identity matrix', function() {
     var transform = new CSSTransformValue();
     assert.isTrue(transform.is2D());
-    assert.isTrue(transform.cssString == "");
+    assert.isTrue(transform.cssText == "");
     assert.deepEqual(transform.asMatrix(), new CSSMatrix(1, 0, 0, 1, 0, 0));
   });
 
@@ -31,7 +31,7 @@ suite('CSSTransformValue', function() {
     var values = [scale];
     assert.doesNotThrow(function() {transform = new CSSTransformValue(values)});
     assert.isTrue(transform.is2D());
-    assert.strictEqual(transform.cssString, scale.cssString);
+    assert.strictEqual(transform.cssText, scale.cssText);
     assert.deepEqual(transform.asMatrix(), scale.asMatrix());
   });
 
@@ -42,12 +42,12 @@ suite('CSSTransformValue', function() {
     var values = [scale, scale];
     assert.doesNotThrow(function() {transform = new CSSTransformValue(values)});
     assert.isTrue(transform.is2D());
-    assert.strictEqual(transform.cssString,
-        scale.cssString + ' ' + scale.cssString);
+    assert.strictEqual(transform.cssText,
+        scale.cssText + ' ' + scale.cssText);
 
     var expectedMatrix = scale.asMatrix().multiply(scale.asMatrix());
     var transformMatrix = transform.asMatrix();
-    assert.strictEqual(transformMatrix.cssString, expectedMatrix.cssString);
+    assert.strictEqual(transformMatrix.cssText, expectedMatrix.cssText);
     assert.deepEqual(transformMatrix, expectedMatrix);
   });
 
@@ -59,12 +59,12 @@ suite('CSSTransformValue', function() {
     var values = [matrix, scale];
     assert.doesNotThrow(function() {transform = new CSSTransformValue(values)});
     assert.isTrue(transform.is2D());
-    assert.strictEqual(transform.cssString,
-        values[0].cssString + ' ' + values[1].cssString);
+    assert.strictEqual(transform.cssText,
+        values[0].cssText + ' ' + values[1].cssText);
 
     var expectedMatrix = values[0].asMatrix().multiply(values[1].asMatrix());
     var transformMatrix = transform.asMatrix();
-    assert.strictEqual(transformMatrix.cssString, expectedMatrix.cssString);
+    assert.strictEqual(transformMatrix.cssText, expectedMatrix.cssText);
     assert.deepEqual(transformMatrix, expectedMatrix);
   });
 
@@ -76,12 +76,12 @@ suite('CSSTransformValue', function() {
     var values = [matrix, scale];
     assert.doesNotThrow(function() {transform = new CSSTransformValue(values)});
     assert.isFalse(transform.is2D());
-    assert.strictEqual(transform.cssString,
-        values[0].cssString + ' ' + values[1].cssString);
+    assert.strictEqual(transform.cssText,
+        values[0].cssText + ' ' + values[1].cssText);
 
     var expectedMatrix = values[0].asMatrix().multiply(values[1].asMatrix());
     var transformMatrix = transform.asMatrix();
-    assert.strictEqual(transformMatrix.cssString, expectedMatrix.cssString);
+    assert.strictEqual(transformMatrix.cssText, expectedMatrix.cssText);
     assert.deepEqual(transformMatrix, expectedMatrix);
   });
 
@@ -96,8 +96,8 @@ suite('CSSTransformValue', function() {
     var values = [matrix2d, scale3d, matrix2d, skew, matrix3d, scale2d];
     assert.doesNotThrow(function() {transform = new CSSTransformValue(values)});
     assert.isFalse(transform.is2D());
-    assert.strictEqual(transform.cssString,
-        values.map(function(value) {return value.cssString}).join(' '));
+    assert.strictEqual(transform.cssText,
+        values.map(function(value) {return value.cssText}).join(' '));
 
     var expectedMatrix = values[0].asMatrix();
     for (var i = 1; i < values.length; ++i) {
@@ -105,7 +105,7 @@ suite('CSSTransformValue', function() {
     }
 
     var transformMatrix = transform.asMatrix();
-    assert.strictEqual(transformMatrix.cssString, expectedMatrix.cssString);
+    assert.strictEqual(transformMatrix.cssText, expectedMatrix.cssText);
     assert.deepEqual(transformMatrix, expectedMatrix);
   });
 });

--- a/test/js/css-translation.js
+++ b/test/js/css-translation.js
@@ -53,12 +53,12 @@ suite('CSSTranslation', function() {
     assert.deepEqual(translation.y, y);
 
     assert.isTrue(translation.is2DComponent());
-    assert.strictEqual(translation.cssString,
-        'translate(' + x.cssString + ', ' + y.cssString + ')');
+    assert.strictEqual(translation.cssText,
+        'translate(' + x.cssText + ', ' + y.cssText + ')');
 
     var expectedMatrix = new CSSMatrix(1, 0, 0, 1, 3, -1);
-    assert.strictEqual(translation.asMatrix().cssString,
-        expectedMatrix.cssString);
+    assert.strictEqual(translation.asMatrix().cssText,
+        expectedMatrix.cssText);
     assert.deepEqual(translation.asMatrix(), expectedMatrix);
   });
 
@@ -78,14 +78,14 @@ suite('CSSTranslation', function() {
 
     assert.isFalse(translation.is2DComponent());
 
-    var expectedCssString = 'translate3d(' + x.cssString + ', ' + y.cssString +
-        ', ' + z.cssString + ')';
-    assert.strictEqual(translation.cssString, expectedCssString);
+    var expectedCssString = 'translate3d(' + x.cssText + ', ' + y.cssText +
+        ', ' + z.cssText + ')';
+    assert.strictEqual(translation.cssText, expectedCssString);
 
     var expectedMatrix = new CSSMatrix(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 3, 0.5,
         -4, 1);
-    assert.strictEqual(translation.asMatrix().cssString,
-        expectedMatrix.cssString);
+    assert.strictEqual(translation.asMatrix().cssText,
+        expectedMatrix.cssText);
     assert.deepEqual(translation.asMatrix(), expectedMatrix);
   });
 });

--- a/test/js/inline-style-property-map.js
+++ b/test/js/inline-style-property-map.js
@@ -18,7 +18,7 @@ suite('Inline StylePropertyMap', function() {
     var simpleLength = new CSSSimpleLength(9.2, 'percent');
     inlineStyleMap.set('height', simpleLength);
 
-    assert.strictEqual(this.element.style['height'], simpleLength.cssString);
+    assert.strictEqual(this.element.style['height'], simpleLength.cssText);
   });
 
   test('Set successfully sets the style string for the list of CSSStyleValues on a property that supports sequences', function() {

--- a/test/js/inline-style-property-map.js
+++ b/test/js/inline-style-property-map.js
@@ -160,4 +160,8 @@ suite('Inline StylePropertyMap', function() {
 
     assert.deepEqual(inlineStyleMap.getProperties(), ['opacity', 'height', 'border-top-color', 'border-top-width']);
   });
+
+  test('Getting an unset value does not throw', function() {
+    assert.isNull(this.element.styleMap().get('height'));
+  });
 });


### PR DESCRIPTION
This add support for getting a base CSSStyleValue from the StylePropertyMaps. I wasn't sure how to allow construction of base CSSStyleValues for this purpose but disallow it for developers using this. Any suggestions?

Also fixed bug where an exception is thrown in Inline StylePropertyMap get method if the property is unset.

Note also that I have used "cssText" instead of "cssString" in this patch so that when https://github.com/css-typed-om/typed-om/pull/91 is merged it won't also need to be renamed.
