### PR TITLE
Rename is2DComponent to is2D.

### DIFF
--- a/src/css-matrix.js
+++ b/src/css-matrix.js
@@ -75,7 +75,7 @@
     return this;
   };
 
-  CSSMatrix.prototype.is2DComponent = function() {
+  CSSMatrix.prototype.is2D = function() {
     return this._matrix.length == 6;
   };
 
@@ -84,7 +84,7 @@
       throw new TypeError('Expected a single argument of type CSSMatrix');
     }
 
-    if (this.is2DComponent() && rightMatrix.is2DComponent()) {
+    if (this.is2D() && rightMatrix.is2D()) {
       return CSSMatrix._multiply2DMatrices(this, rightMatrix);
     }
 
@@ -94,7 +94,7 @@
   };
 
   CSSMatrix.prototype.to3DComponent = function() {
-    if (!this.is2DComponent()) {
+    if (!this.is2D()) {
       return this;
     }
 
@@ -112,7 +112,7 @@
   };
 
   CSSMatrix.prototype._generateCssString = function() {
-    var cssString = this.is2DComponent() ? 'matrix' : 'matrix3d';
+    var cssString = this.is2D() ? 'matrix' : 'matrix3d';
     cssString += '('+ this._matrix.join(', ') + ')';
     return cssString;
   };

--- a/src/css-rotation.js
+++ b/src/css-rotation.js
@@ -77,7 +77,7 @@
 
   CSSRotation.prototype._generateCssString = function() {
     var cssString;
-    if (this.is2DComponent()) {
+    if (this.is2D()) {
       cssString = 'rotate(' + this.angle + 'deg)';
     } else {
       cssString = 'rotate3d(' + this.x + ', ' + this.y + ', ' + this.z + ', ' +

--- a/src/css-scale.js
+++ b/src/css-scale.js
@@ -51,7 +51,7 @@
 
   CSSScale.prototype._generateCssString = function() {
     var cssString;
-    if (this.is2DComponent()) {
+    if (this.is2D()) {
       cssString = 'scale(' + this.x + ', ' + this.y + ')';
     } else {
       cssString = 'scale3d(' + this.x + ', ' + this.y + ', ' + this.z + ')';

--- a/src/css-transform-component.js
+++ b/src/css-transform-component.js
@@ -21,8 +21,8 @@
     throw new TypeError('Should not be reached.');
   };
 
-  CSSTransformComponent.prototype.is2DComponent = function() {
-    return this.asMatrix().is2DComponent();
+  CSSTransformComponent.prototype.is2D = function() {
+    return this.asMatrix().is2D();
   };
 
   internal.CSSTransformComponent = CSSTransformComponent;

--- a/src/css-transform-value.js
+++ b/src/css-transform-value.js
@@ -42,7 +42,7 @@
   };
 
   CSSTransformValue.prototype.is2D = function() {
-    return this.asMatrix().is2DComponent();
+    return this.asMatrix().is2D();
   };
 
   CSSTransformValue.prototype._computeMatrix = function() {

--- a/src/css-translation.js
+++ b/src/css-translation.js
@@ -56,7 +56,7 @@
 
   CSSTranslation.prototype._generateCssString = function() {
     var cssString;
-    if (this.is2DComponent()) {
+    if (this.is2D()) {
       cssString = 'translate(' + this.x.cssString + ', ' + this.y.cssString +
           ')';
     } else {

--- a/test/js/css-matrix.js
+++ b/test/js/css-matrix.js
@@ -19,7 +19,7 @@ suite('CSSMatrix', function() {
     assert.doesNotThrow(function() {
       value = new CSSMatrix(10, 20, -0.5, 0.5, 4, 2);
     });
-    assert.isTrue(value.is2DComponent());
+    assert.isTrue(value.is2D());
     assert.strictEqual(value.cssString,
       'matrix(10, 20, -0.5, 0.5, 4, 2)');
     assert.strictEqual(value._matrix.length, 6);
@@ -34,7 +34,7 @@ suite('CSSMatrix', function() {
     assert.doesNotThrow(function() {
       value = new CSSMatrix(10, 20, 0, 0, -0.5, 0.5, 0, 0, 0, 0, 1, 0, 4, 2, 0, 1);
     });
-    assert.isFalse(value.is2DComponent());
+    assert.isFalse(value.is2D());
     assert.strictEqual(value._matrix.length, 16);
     assert.strictEqual(value.cssString,
       'matrix3d(10, 20, 0, 0, -0.5, 0.5, 0, 0, 0, 0, 1, 0, 4, 2, 0, 1)');
@@ -47,17 +47,17 @@ suite('CSSMatrix', function() {
     var identity2D = new CSSMatrix(1, 0, 0, 1, 0, 0);
     var identity3D = new CSSMatrix(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);
 
-    assert.isTrue(identity2D.is2DComponent());
+    assert.isTrue(identity2D.is2D());
 
-    assert.isFalse(identity3D.is2DComponent());
+    assert.isFalse(identity3D.is2D());
 
     var identity2DTo3D = identity2D.to3DComponent();
-    assert.isFalse(identity2DTo3D.is2DComponent());
+    assert.isFalse(identity2DTo3D.is2D());
     assert.strictEqual(identity2DTo3D.cssString, identity3D.cssString);
     assert.deepEqual(identity2DTo3D, identity3D);
 
     var identity3DTo3D = identity3D.to3DComponent();
-    assert.isFalse(identity3DTo3D.is2DComponent());
+    assert.isFalse(identity3DTo3D.is2D());
     assert.strictEqual(identity3DTo3D.cssString, identity3D.cssString);
     assert.deepEqual(identity3DTo3D, identity3D);
     assert.deepEqual(identity3DTo3D, identity2DTo3D);
@@ -68,16 +68,16 @@ suite('CSSMatrix', function() {
     var random3D =
       new CSSMatrix(10, 20, 0, 0, -0.5, 0.5, 0, 0, 0, 0, 1, 0, 4, 2, 0, 1);
 
-    assert.isTrue(random2D.is2DComponent());
-    assert.isFalse(random3D.is2DComponent());
+    assert.isTrue(random2D.is2D());
+    assert.isFalse(random3D.is2D());
 
     var random2DTo3D = random2D.to3DComponent();
-    assert.isFalse(random2DTo3D.is2DComponent());
+    assert.isFalse(random2DTo3D.is2D());
     assert.strictEqual(random2DTo3D.cssString, random3D.cssString);
     assert.deepEqual(random2DTo3D, random3D);
 
     var random3DTo3D = random3D.to3DComponent();
-    assert.isFalse(random3DTo3D.is2DComponent());
+    assert.isFalse(random3DTo3D.is2D());
     assert.strictEqual(random3DTo3D.cssString, random3D.cssString);
     assert.deepEqual(random3DTo3D, random3D);
   });
@@ -88,7 +88,7 @@ suite('CSSMatrix', function() {
     var result = identity2D.multiply(identity2D);
     assert.instanceOf(result, CSSMatrix,
       'CSSMatrix multiply returns an instance of CSSMatrix');
-    assert.isTrue(result.is2DComponent());
+    assert.isTrue(result.is2D());
     assert.deepEqual(result, identity2D);
   });
 
@@ -98,7 +98,7 @@ suite('CSSMatrix', function() {
     var result = identity3D.multiply(identity3D);
     assert.instanceOf(result, CSSMatrix,
       'CSSMatrix multiply returns an instance of CSSMatrix');
-    assert.isFalse(result.is2DComponent());
+    assert.isFalse(result.is2D());
     assert.deepEqual(result, identity3D);
   });
 
@@ -107,12 +107,12 @@ suite('CSSMatrix', function() {
     var identity3D = new CSSMatrix(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);
 
     var multiply2DAnd3D = identity2D.multiply(identity3D);
-    assert.isFalse(multiply2DAnd3D.is2DComponent());
+    assert.isFalse(multiply2DAnd3D.is2D());
     assert.strictEqual(multiply2DAnd3D.cssString, identity3D.cssString);
     assert.deepEqual(multiply2DAnd3D, identity3D);
 
     var multiply3DAnd2D = identity3D.multiply(identity2D);
-    assert.isFalse(multiply3DAnd2D.is2DComponent());
+    assert.isFalse(multiply3DAnd2D.is2D());
     assert.strictEqual(multiply2DAnd3D.cssString, identity3D.cssString);
     assert.deepEqual(multiply3DAnd2D, identity3D);
   });
@@ -123,7 +123,7 @@ suite('CSSMatrix', function() {
     var expectedResult = new CSSMatrix(-20, -40, 488.5, 981.5, 73.6, 142.4);
 
     var result = random1.multiply(random2);
-    assert.isTrue(result.is2DComponent());
+    assert.isTrue(result.is2D());
     assert.strictEqual(result.cssString, expectedResult.cssString);
     assert.deepEqual(result, expectedResult);
   });
@@ -140,13 +140,13 @@ suite('CSSMatrix', function() {
             23);
 
     var multiply2DAnd3D = random2D.multiply(random3D);
-    assert.isFalse(multiply2DAnd3D.is2DComponent());
+    assert.isFalse(multiply2DAnd3D.is2D());
     assert.strictEqual(multiply2DAnd3D.cssString,
         expectedMultiply2DAnd3D.cssString);
     assert.deepEqual(multiply2DAnd3D, expectedMultiply2DAnd3D);
 
     var multiply3DAnd2D = random3D.multiply(random2D);
-    assert.isFalse(multiply3DAnd2D.is2DComponent());
+    assert.isFalse(multiply3DAnd2D.is2D());
     assert.strictEqual(multiply3DAnd2D.cssString,
         expectedMultiply3DAnd2D.cssString);
     assert.deepEqual(multiply3DAnd2D, expectedMultiply3DAnd2D);
@@ -162,7 +162,7 @@ suite('CSSMatrix', function() {
             119.5, 210.5, 3, 5);
 
     var result = random1.multiply(random2);
-    assert.isFalse(result.is2DComponent());
+    assert.isFalse(result.is2D());
     assert.strictEqual(result.cssString, expectedResult.cssString);
     assert.deepEqual(result, expectedResult);
   });

--- a/test/js/css-perspective.js
+++ b/test/js/css-perspective.js
@@ -35,7 +35,7 @@ suite('CSSPerspective', function() {
         'perspective(' + length.cssString + ')');
     assert.strictEqual(perspective.length.value, 10);
     assert.deepEqual(perspective.length, length);
-    assert.isFalse(perspective.is2DComponent());
+    assert.isFalse(perspective.is2D());
 
     var expectedMatrix = new CSSMatrix(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, -0.1, 0, 0,
         0, 1);

--- a/test/js/css-rotation.js
+++ b/test/js/css-rotation.js
@@ -1,8 +1,8 @@
 suite('CSSRotation', function() {
   function assertMatrixCloseTo(actualMatrix, expectedMatrix) {
     var delta = 0.000001;
-    assert.strictEqual(actualMatrix.is2DComponent(),
-        expectedMatrix.is2DComponent());
+    assert.strictEqual(actualMatrix.is2D(),
+        expectedMatrix.is2D());
     for (var i = 0; i < expectedMatrix._matrix.length; i++) {
       assert.closeTo(actualMatrix._matrix[i], expectedMatrix._matrix[i], delta);
     }
@@ -34,7 +34,7 @@ suite('CSSRotation', function() {
     assert.isNull(rotation.x);
     assert.isNull(rotation.y);
     assert.isNull(rotation.z);
-    assert.isTrue(rotation.is2DComponent());
+    assert.isTrue(rotation.is2D());
 
     var sinCos = Math.sqrt(3) / 4;
     var expectedMatrix = new CSSMatrix(0.5, 2 * sinCos, -2 * sinCos, 0.5, 0, 0);
@@ -49,7 +49,7 @@ suite('CSSRotation', function() {
     assert.strictEqual(rotation.x, 1);
     assert.strictEqual(rotation.y, 0.5);
     assert.strictEqual(rotation.z, -2);
-    assert.isFalse(rotation.is2DComponent());
+    assert.isFalse(rotation.is2D());
 
     var expectedMatrix = new CSSMatrix(0.89154437, -0.42367629, -0.16014688, 0,
         0.44919526, 0.872405146, 0.19269891, 0, 0.05807100, -0.243736860,
@@ -77,8 +77,8 @@ suite('CSSRotation', function() {
   test('CSSRotation(angle) equivalent to CSSRotation(angle, 0, 0, 1)', function() {
     var rotation2D = new CSSRotation(30);
     var rotation3D = new CSSRotation(30, 0, 0, 1);
-    assert.isTrue(rotation2D.is2DComponent());
-    assert.isFalse(rotation3D.is2DComponent());
+    assert.isTrue(rotation2D.is2D());
+    assert.isFalse(rotation3D.is2D());
     assertMatrixCloseTo(rotation3D.asMatrix(),
         rotation2D.asMatrix().to3DComponent());
   });

--- a/test/js/css-scale.js
+++ b/test/js/css-scale.js
@@ -23,7 +23,7 @@ suite('CSSScale', function() {
     assert.strictEqual(scale.x, 3);
     assert.strictEqual(scale.y, -1);
     assert.isNull(scale.z);
-    assert.isTrue(scale.is2DComponent());
+    assert.isTrue(scale.is2D());
 
     var expectedMatrix = new CSSMatrix(3, 0, 0, -1, 0, 0);
     assert.strictEqual(scale.asMatrix().cssString, expectedMatrix.cssString);
@@ -37,7 +37,7 @@ suite('CSSScale', function() {
     assert.strictEqual(scale.x, 3);
     assert.strictEqual(scale.y, 0.5);
     assert.strictEqual(scale.z, -4);
-    assert.isFalse(scale.is2DComponent());
+    assert.isFalse(scale.is2D());
 
     var expectedMatrix = new CSSMatrix(3, 0, 0, 0, 0, 0.5, 0, 0, 0, 0, -4, 0, 0, 0,
         0, 1);

--- a/test/js/css-skew.js
+++ b/test/js/css-skew.js
@@ -22,7 +22,7 @@ suite('CSSSkew', function() {
     assert.strictEqual(skew.cssString, 'skew(30deg, 180deg)');
     assert.strictEqual(skew.ax, 30);
     assert.strictEqual(skew.ay, 180);
-    assert.isTrue(skew.is2DComponent());
+    assert.isTrue(skew.is2D());
 
     var tanAx = CSSSkew._tanDegrees(30);
     var tanAy = CSSSkew._tanDegrees(180);

--- a/test/js/css-transform-component.js
+++ b/test/js/css-transform-component.js
@@ -1,7 +1,7 @@
 suite('CSSTransformComponent', function() {
-  test('asMatrix and is2DComponent methods throw errors', function() {
+  test('asMatrix and is2D methods throw errors', function() {
     var component = new CSSTransformComponent();
     assert.throws(function() {component.asMatrix()});
-    assert.throws(function() {component.is2DComponent()});
+    assert.throws(function() {component.is2D()});
   });
 });

--- a/test/js/css-translation.js
+++ b/test/js/css-translation.js
@@ -52,7 +52,7 @@ suite('CSSTranslation', function() {
     assert.deepEqual(translation.x, x);
     assert.deepEqual(translation.y, y);
 
-    assert.isTrue(translation.is2DComponent());
+    assert.isTrue(translation.is2D());
     assert.strictEqual(translation.cssString,
         'translate(' + x.cssString + ', ' + y.cssString + ')');
 
@@ -76,7 +76,7 @@ suite('CSSTranslation', function() {
     assert.deepEqual(translation.y, y);
     assert.deepEqual(translation.z, z);
 
-    assert.isFalse(translation.is2DComponent());
+    assert.isFalse(translation.is2D());
 
     var expectedCssString = 'translate3d(' + x.cssString + ', ' + y.cssString +
         ', ' + z.cssString + ')';


### PR DESCRIPTION
This is an automated rename of CSSTransformValue.is2DComponent and CSSTransformComponent.is2DComponent to just is2D.

The command used was

grep -rl is2DComponent . | xargs sed -i -e 's/is2DComponent/is2D/'

See the spec here: https://drafts.css-houdini.org/css-typed-om/#transformvalue-objects, https://drafts.css-houdini.org/css-typed-om/#csstransformcomponent
