### PR TITLE
Make semi-private methods in LengthValues properly hidden

### DIFF
--- a/src/css-calc-length.js
+++ b/src/css-calc-length.js
@@ -103,9 +103,7 @@
 
     // Iterate through all possible length types and add their values.
     internal.objects.foreach(CSSLengthValue.LengthType, function(type) {
-      if (calcLength[type] == null && addedLength[type] == null) {
-        calcDictionary[type] = null;
-      } else if (calcLength[type] == null) {
+      if (calcLength[type] == null) {
         calcDictionary[type] = addedLength[type];
       } else if (addedLength[type] == null) {
         calcDictionary[type] = calcLength[type];

--- a/src/css-calc-length.js
+++ b/src/css-calc-length.js
@@ -14,6 +14,7 @@
 
 (function(internal, scope) {
 
+  // TODO: CSSCalcLength(cssString)
   function CSSCalcLength(dictionary) {
     if (typeof dictionary != 'object') {
       throw new TypeError('CSSCalcLength must be passed a dictionary object');

--- a/src/css-length-value.js
+++ b/src/css-length-value.js
@@ -101,11 +101,9 @@
     if (this instanceof CSSSimpleLength &&
         addedLength instanceof CSSSimpleLength &&
         this.type == addedLength.type) {
-      return this._addSimpleLengths(addedLength);
+      return internal.addSimpleLengths(this, addedLength);
     } else if (addedLength instanceof CSSLengthValue) {
-      // Ensure both lengths are of type CSSCalcLength before adding
-      return this._asCalcLength()._addCalcLengths(
-          addedLength._asCalcLength());
+      return internal.simpleLengthToCalcLength(this).add(addedLength);
     } else {
       throw new TypeError('Argument must be a CSSLengthValue');
     }
@@ -115,11 +113,9 @@
     if (this instanceof CSSSimpleLength &&
         subtractedLength instanceof CSSSimpleLength &&
         this.type == subtractedLength.type) {
-      return this._subtractSimpleLengths(subtractedLength);
+      return internal.subtractSimpleLengths(this, subtractedLength);
     } else if (subtractedLength instanceof CSSLengthValue) {
-      // Ensure both lengths are of type CSSCalcLength before subtracting
-      return this._asCalcLength()._subtractCalcLengths(
-          subtractedLength._asCalcLength());
+      return internal.simpleLengthToCalcLength(this).subtract(subtractedLength);
     } else {
       throw new TypeError('Argument must be a CSSLengthValue');
     }
@@ -130,10 +126,6 @@
   };
 
   CSSLengthValue.prototype.divide = function(divider) {
-    throw new TypeError('Should not be reached');
-  };
-
-  CSSLengthValue.prototype._asCalcLength = function() {
     throw new TypeError('Should not be reached');
   };
 

--- a/src/css-simple-length.js
+++ b/src/css-simple-length.js
@@ -39,29 +39,29 @@
     return new CSSSimpleLength((this.value / divider), this.type);
   };
 
-  CSSSimpleLength.prototype._addSimpleLengths = function(addedLength) {
+  function addSimpleLengths(length, addedLength) {
     if (!(addedLength instanceof CSSSimpleLength)) {
       throw new TypeError('Argument must be a CSSSimpleLength');
     }
-    if (this.type != addedLength.type) {
+    if (length.type != addedLength.type) {
       throw new TypeError('CSSSimpleLength units are not the same');
     }
-    return new CSSSimpleLength((this.value + addedLength.value), this.type);
+    return new CSSSimpleLength(length.value + addedLength.value, length.type);
   };
 
-  CSSSimpleLength.prototype._subtractSimpleLengths = function(subtractedLength) {
+  function subtractSimpleLengths(length, subtractedLength) {
     if (!(subtractedLength instanceof CSSSimpleLength)) {
       throw new TypeError('Argument must be a CSSSimpleLength');
     }
-    if (this.type != subtractedLength.type) {
+    if (length.type != subtractedLength.type) {
       throw new TypeError('CSSSimpleLength units are not the same');
     }
-    return new CSSSimpleLength((this.value - subtractedLength.value), this.type);
+    return new CSSSimpleLength(length.value - subtractedLength.value, length.type);
   };
 
-  CSSSimpleLength.prototype._asCalcLength = function() {
+  function toCalcLength(simpleLength) {
     var calcDictionary = {};
-    calcDictionary[this.type] = this.value;
+    calcDictionary[simpleLength.type] = simpleLength.value;
     return new CSSCalcLength(calcDictionary);
   };
 
@@ -82,5 +82,9 @@
   };
 
   scope.CSSSimpleLength = CSSSimpleLength;
+
+  internal.addSimpleLengths = addSimpleLengths;
+  internal.subtractSimpleLengths = subtractSimpleLengths;
+  internal.simpleLengthToCalcLength = toCalcLength;
 
 })(typedOM.internal, window);

--- a/src/css-simple-length.js
+++ b/src/css-simple-length.js
@@ -59,7 +59,7 @@
     return new CSSSimpleLength(length.value - subtractedLength.value, length.type);
   };
 
-  function toCalcLength(simpleLength) {
+  function simpleLengthToCalcLength(simpleLength) {
     var calcDictionary = {};
     calcDictionary[simpleLength.type] = simpleLength.value;
     return new CSSCalcLength(calcDictionary);
@@ -85,6 +85,6 @@
 
   internal.addSimpleLengths = addSimpleLengths;
   internal.subtractSimpleLengths = subtractSimpleLengths;
-  internal.simpleLengthToCalcLength = toCalcLength;
+  internal.simpleLengthToCalcLength = simpleLengthToCalcLength;
 
 })(typedOM.internal, window);

--- a/test/js/css-calc-length.js
+++ b/test/js/css-calc-length.js
@@ -154,13 +154,6 @@ suite('CSSCalcLength', function() {
     assert.strictEqual(null, result.em);
   });
 
-  test('_asCalcLength method returns the object that called it if it is of type CSSCalcLength', function() {
-    var calcLength = new CSSCalcLength({px: 25, em: 3.2});
-    var result = calcLength._asCalcLength();
-
-    assert.strictEqual(calcLength, result);
-  });
-
   test('CSSCalcLength.equals returns true if the compared CSSCalcLengths are the same', function() {
     var calcLength1 = new CSSCalcLength({px: 25, em: 3.2});
     var calcLength2 = new CSSCalcLength({px: 25, em: 3.2});

--- a/test/js/css-simple-length.js
+++ b/test/js/css-simple-length.js
@@ -82,7 +82,7 @@ suite('CSSSimpleLength', function() {
     var simpleLength1 = new CSSSimpleLength(10, 'em');
     var simpleLength2 = new CSSSimpleLength(5, 'em');
     var result = simpleLength1.add(simpleLength2);
-    assert.instanceOf(result, CSSSimpleLength, 'Two added CSSSimpleLengths of same type should return an instance of CSSSimpleLength');
+    assert.instanceOf(result, CSSSimpleLength);
     assert.strictEqual(result.type, 'em');
     assert.strictEqual(result.value, 15);
   });
@@ -92,7 +92,7 @@ suite('CSSSimpleLength', function() {
     var simpleLength2 = new CSSSimpleLength(5, 'px');
     var result = simpleLength1.add(simpleLength2);
     var expectedResult = new CSSCalcLength({em: 10, px: 5});
-    assert.instanceOf(result, CSSCalcLength, 'Two added CSSSimpleLengths of different types should return an instance of CSSCalcLength');
+    assert.instanceOf(result, CSSCalcLength);
     assert.isTrue(expectedResult.equals(result));
   });
 
@@ -112,13 +112,6 @@ suite('CSSSimpleLength', function() {
     var expectedResult = new CSSCalcLength({em: 10, px: -5});
     assert.instanceOf(result, CSSCalcLength, 'Two subtracted CSSSimpleLengths of different types should return an instance of CSSCalcLength');
     assert.isTrue(expectedResult.equals(result));
-  });
-
-  test('_asCalcLength method returns a CSSCalcLength with single value', function() {
-    var simpleLength = new CSSSimpleLength(10, 'em');
-    var result = simpleLength._asCalcLength();
-    var expectedResult = new CSSCalcLength({em: 10});
-    assert.isTrue(result.equals(expectedResult));
   });
 
   test('equals method should return true for equal CSSSimpleLengths', function() {


### PR DESCRIPTION
Here I've used scoping to fully hide most methods we don't want developers to see. Some were needed in LengthValue (simpleLengthToCalcLength, addSimpleLengths, subtractSimpleLengths), so I put them in in the internal scope. I think this makes LengthValue's add and subtract methods much tidier - WDYT?
