### PR TITLE
Implement parsing for CSSPositionValue

### DIFF
--- a/src/css-position-value-parsing.js
+++ b/src/css-position-value-parsing.js
@@ -22,7 +22,6 @@
     if (!params || params[0].length != 2) {
       return;
     }
-    console.log(params);
     var lengths = params[0];
     return [new CSSPositionValue(lengths[0], lengths[1]), params[1]];
   }

--- a/src/css-position-value-parsing.js
+++ b/src/css-position-value-parsing.js
@@ -1,0 +1,31 @@
+// Copyright 2016 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//     You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//     See the License for the specific language governing permissions and
+// limitations under the License.
+
+(function(internal) {
+
+  function parsePositionValue(str) {
+    var params = internal.parsing.consumeRepeated(
+        internal.parsing.consumeLengthValue,
+        null, // separator not required due to use of consumeTrimmed.
+        str);
+    if (!params || params[0].length != 2) {
+      return;
+    }
+    console.log(params);
+    var lengths = params[0];
+    return [new CSSPositionValue(lengths[0], lengths[1]), params[1]];
+  }
+
+  internal.parsing.parsePositionValue = parsePositionValue;
+})(typedOM.internal);

--- a/src/css-position-value.js
+++ b/src/css-position-value.js
@@ -14,6 +14,10 @@
 
 (function(internal, scope) {
 
+  function generateCssString(positionValue) {
+    return positionValue.x.cssText + ' ' + positionValue.y.cssText;
+  };
+
   /**
    * CSSPositionValue(xPos, yPos)
    */
@@ -28,13 +32,9 @@
 
     this.x = new CSSLengthValue(xPos);
     this.y = new CSSLengthValue(yPos);
-    this.cssText = this._generateCssString();
+    this.cssText = generateCssString(this);
   }
   internal.inherit(CSSPositionValue, CSSStyleValue);
-
-  CSSPositionValue.prototype._generateCssString = function() {
-    return this.x.cssText + ' ' + this.y.cssText;
-  };
 
   scope.CSSPositionValue = CSSPositionValue;
 

--- a/src/parsing.js
+++ b/src/parsing.js
@@ -72,11 +72,13 @@
       }
       list.push(result[0]);
       string = result[1];
-      result = consumeToken(separator, string);
-      if (!result || result[1] == '') {
-        return [list, string];
+      if (separator) {
+        result = consumeToken(separator, string);
+        if (!result || result[1] == '') {
+          return [list, string];
+        }
+        string = result[1];
       }
-      string = result[1];
     }
   }
 

--- a/target-config.js
+++ b/target-config.js
@@ -18,20 +18,12 @@
       'src/scope.js'
   ];
 
+      // These should be alphabetical order as much as possible.
   var typedOMSrc = [
+      // Utility functions.
       'src/util.js',
       'src/parsing.js',
-      'src/css-style-value.js',
-      'src/css-variable-reference-value.js',
-      'src/css-angle-value.js',
-      'src/css-number-value.js',
-      'src/css-keyword-value.js',
-      'src/css-length-value.js',
-      'src/css-length-value-parsing.js',
-      'src/css-simple-length.js',
-      'src/css-calc-length.js',
-      'src/css-position-value.js',
-      'src/css-color-value.js',
+      // CSSTransformComponent and subclasses
       'src/css-transform-component.js',
       'src/css-matrix.js',
       'src/css-perspective.js',
@@ -39,7 +31,22 @@
       'src/css-scale.js',
       'src/css-skew.js',
       'src/css-translation.js',
+      // CSSStyleValue and subclasses
+      'src/css-style-value.js',
+      'src/css-angle-value.js',
+      'src/css-color-value.js',
+      'src/css-number-value.js',
+      'src/css-keyword-value.js',
       'src/css-transform-value.js',
+      'src/css-variable-reference-value.js',
+      // CSSLengthValue and subclasses
+      'src/css-length-value.js',
+      'src/css-simple-length.js',
+      'src/css-calc-length.js',
+      'src/css-length-value-parsing.js',
+      'src/css-position-value.js', // Depends on LengthValues.
+      'src/css-position-value-parsing.js',
+      // Other stuff.
       'src/dom-matrix-readonly.js',
       'src/style-property-map-readonly.js',
       'src/style-property-map.js',
@@ -48,27 +55,27 @@
 
   var typedOMTest = [
       'test/js/css-angle-value.js',
-      'test/js/css-number-value.js',
-      'test/js/css-variable-reference-value.js',
+      'test/js/css-calc-length.js',
+      'test/js/css-color-value.js',
       'test/js/css-keyword-value.js',
       'test/js/css-length-value.js',
-      'test/js/css-simple-length.js',
-      'test/js/css-position-value.js',
-      'test/js/css-color-value.js',
-      'test/js/css-calc-length.js',
-      'test/js/css-transform-component.js',
       'test/js/css-matrix.js',
+      'test/js/css-number-value.js',
       'test/js/css-perspective.js',
+      'test/js/css-position-value.js',
       'test/js/css-rotation.js',
       'test/js/css-scale.js',
+      'test/js/css-simple-length.js',
       'test/js/css-skew.js',
+      'test/js/css-style-value.js',
+      'test/js/css-transform-component.js',
       'test/js/css-translation.js',
       'test/js/css-transform-value.js',
+      'test/js/css-variable-reference-value.js',
       'test/js/computed-style-property-map.js',
       'test/js/dom-matrix-readonly.js',
       'test/js/inline-style-property-map.js',
       'test/js/property-dictionary.js',
-      'test/js/css-style-value.js'
   ];
 
   // This object specifies the source and test files for different build targets.

--- a/test/js/css-position-value.js
+++ b/test/js/css-position-value.js
@@ -1,17 +1,3 @@
-// Copyright 2016 Google Inc. All rights reserved.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-//     You may obtain a copy of the License at
-//
-// http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-//     See the License for the specific language governing permissions and
-// limitations under the License.
-
 suite('CSSPositionValue', function() {
 
   test('Constructor throws if xPos or yPos is not a CSSLengthValue', function() {

--- a/test/js/css-position-value.js
+++ b/test/js/css-position-value.js
@@ -1,14 +1,58 @@
+// Copyright 2016 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//     You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//     See the License for the specific language governing permissions and
+// limitations under the License.
+
 suite('CSSPositionValue', function() {
-  test('If either xPos or yPos is not a CSSLengthValue object then the constructor should throw a type error', function() {
-    assert.throws(function() { new CSSPositionValue(2, 3) }, 'xPos is not a CSSLengthValue object');
-    assert.throws(function() { new CSSPositionValue(new CSSSimpleLength(3, 'px'), 3) }, 'yPos is not a CSSLengthValue object');
+
+  test('Constructor throws if xPos or yPos is not a CSSLengthValue', function() {
+    assert.throws(function() { new CSSPositionValue(2, 3) });
+    assert.throws(function() { new CSSPositionValue(new CSSSimpleLength(3, 'px'), 3) });
   });
 
-  test('CssStrings created by a CSSPositionValue object should be the x and y css strings separated by a space', function() {
+  test('CSSPositionValue cssText is the x and y cssTexts separated by a space', function() {
     var lengthValue_1 = new CSSCalcLength({px: 10, em: 3.2});
     var lengthValue_2 = new CSSSimpleLength(3, 'px');
     var positionValue = new CSSPositionValue(lengthValue_1, lengthValue_2);
 
     assert.strictEqual(positionValue.cssText, 'calc(10px + 3.2em) 3px');
+  });
+
+  test('Parsing works for simple values', function() {
+    var input = '5px 3px';
+    var result = typedOM.internal.parsing.parsePositionValue(input);
+    assert.strictEqual(result[0].constructor, CSSPositionValue);
+    assert.strictEqual(result[0].cssText, input);
+  });
+
+  test('Parsing works when using calc values', function() {
+    var input = 'calc(-2% + 6em) calc(3vmin - 9pc)';
+    var result = typedOM.internal.parsing.parsePositionValue(input);
+    assert.strictEqual(result[0].constructor, CSSPositionValue);
+    assert.strictEqual(result[0].cssText, input);
+  });
+
+  test('Parsing works when using mixed value types', function() {
+    var input = '99.2px calc(3vmin - 9pc)';
+    var result = typedOM.internal.parsing.parsePositionValue(input);
+    assert.strictEqual(result[0].constructor, CSSPositionValue);
+    assert.strictEqual(result[0].cssText, input);
+  });
+
+  test('Invalid input to parsing returns undefined (and does not throw)', function() {
+    assert.isUndefined(typedOM.internal.parsing.parsePositionValue(''));
+    assert.isUndefined(typedOM.internal.parsing.parsePositionValue('bananas'));
+    assert.isUndefined(typedOM.internal.parsing.parsePositionValue('5px'));
+    assert.isUndefined(typedOM.internal.parsing.parsePositionValue('6px 3'));
+    assert.isUndefined(typedOM.internal.parsing.parsePositionValue('calc(3px - 3em 6px'));
   });
 });


### PR DESCRIPTION
This PR is dependent on both of
css-typed-om#103
css-typed-om#100

I put this up early because I was losing track of what I was working on... I'll assign it when it's ready for review.

This PR also contains these changes:
- Make cssText generator function in CSSPositionValue private
- Make separator optional for consumeRepeated
