### PR TITLE
Add parsing framework for CSSTransformComponents

### DIFF
--- a/src/css-transform-component-parsing.js
+++ b/src/css-transform-component-parsing.js
@@ -1,0 +1,55 @@
+// Copyright 2016 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//     You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//     See the License for the specific language governing permissions and
+// limitations under the License.
+
+(function(internal) {
+  var parsing = internal.parsing;
+
+  function consumeMatrix(string) {
+  }
+
+  function consumePerspective(string) {
+  }
+
+  function consumeRotation(string) {
+  }
+
+  function consumeScale(string) {
+  }
+  
+  function consumeSkew(string) {
+  }
+
+  function consumeTranslate(string) {
+  }
+
+  var transformFunctions = {
+    'matrix': consumeMatrix,
+    'perspective': consumePerspective,
+    'rotate': consumeRotation,
+    'scale': consumeScale,
+    'skew': consumeSkew,
+    'translate': consumeTranslate,
+  };
+
+  function consumeTransformComponent(string) {
+    for (var fn in transformFunctions) {
+      if (string.startsWith(fn)) {
+        return transformFunctions[fn](string);
+      }
+    }
+    return null;
+  }
+
+  internal.parsing.consumeTransformComponent = consumeTransformComponent;
+})(typedOM.internal);

--- a/target-config.js
+++ b/target-config.js
@@ -47,6 +47,8 @@
       'src/css-calc-length.js',
       'src/css-length-value-parsing.js',
       'src/css-position-value.js', // Depends on LengthValues.
+      // Depends on bot transform component subclasses and length parsing.
+      'src/css-transform-component-parsing.js',
       // Other stuff.
       'src/dom-matrix-readonly.js',
       'src/style-property-map-readonly.js',

--- a/target-config.js
+++ b/target-config.js
@@ -47,7 +47,7 @@
       'src/css-calc-length.js',
       'src/css-length-value-parsing.js',
       'src/css-position-value.js', // Depends on LengthValues.
-      // Depends on bot transform component subclasses and length parsing.
+      // Depends on both transform component subclasses and length parsing.
       'src/css-transform-component-parsing.js',
       // Other stuff.
       'src/dom-matrix-readonly.js',
@@ -71,7 +71,6 @@
       'test/js/css-simple-length.js',
       'test/js/css-skew.js',
       'test/js/css-style-value.js',
-      'test/js/css-transform-component.js',
       'test/js/css-translation.js',
       'test/js/css-transform-value.js',
       'test/js/css-variable-reference-value.js',


### PR DESCRIPTION
For now, how does this look as the framework for parsing transform components? The consumeXComponent functions will be moved into the other files and filled in in later PRs.
