### PR TITLE
Add parsing for CSSMatrix

### DIFF
--- a/src/css-matrix-parsing.js
+++ b/src/css-matrix-parsing.js
@@ -1,0 +1,43 @@
+// Copyright 2016 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//     You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//     See the License for the specific language governing permissions and
+// limitations under the License.
+
+(function(internal) {
+  var parsing = internal.parsing;
+
+  function consumeMatrix(string) {
+    var params = parsing.consumeList([
+        parsing.ignore(parsing.consumeToken.bind(null, /^matrix/i)),
+        parsing.optional(parsing.consumeToken.bind(null, /^3d/i)),
+        parsing.ignore(parsing.consumeToken.bind(null, /^\(/)),
+        parsing.consumeRepeated.bind(null, parsing.consumeNumber, /^,/),
+        parsing.ignore(parsing.consumeToken.bind(null, /^\)/)),
+    ], string);
+    if (!params) {
+      return null;
+    }
+    var leftover = params[1];
+    params = params[0];
+    var is3d = !!params[0];
+    var numberSequence = params[1];
+    if (is3d && numberSequence.length != 16) {
+      return null;
+    }
+    if (!is3d && numberSequence.length != 6) {
+      return null;
+    }
+    return [new CSSMatrix(new DOMMatrixReadonly(numberSequence)), leftover];
+  }
+
+  internal.parsing.consumeMatrix = consumeMatrix;
+})(typedOM.internal);

--- a/src/css-matrix-parsing.js
+++ b/src/css-matrix-parsing.js
@@ -16,18 +16,18 @@
   var parsing = internal.parsing;
 
   function consumeMatrix(string) {
-    var params = parsing.consumeList([
+    var result = parsing.consumeList([
         parsing.ignore(parsing.consumeToken.bind(null, /^matrix/i)),
         parsing.optional(parsing.consumeToken.bind(null, /^3d/i)),
         parsing.ignore(parsing.consumeToken.bind(null, /^\(/)),
         parsing.consumeRepeated.bind(null, parsing.consumeNumber, /^,/),
         parsing.ignore(parsing.consumeToken.bind(null, /^\)/)),
     ], string);
-    if (!params) {
+    if (!result) {
       return null;
     }
-    var leftover = params[1];
-    params = params[0];
+    var leftover = result[1];
+    var params = result[0];
     var is3d = !!params[0];
     var numberSequence = params[1];
     if (is3d && numberSequence.length != 16) {

--- a/src/parsing.js
+++ b/src/parsing.js
@@ -35,6 +35,13 @@
     }
   }
 
+  function optional(consumerFn) {
+    return function(input) {
+      var result = consumerFn(input);
+      return result ? result : ['', input];
+    }
+  }
+
   // Regex should be anchored with /^
   function consumeToken(regex, string) {
     var match = regex.exec(string);
@@ -87,7 +94,7 @@
     var output = [];
     for (var i = 0; i < list.length; i++) {
       var result = consumeTrimmed(list[i], input);
-      if (!result || result[0] == '')
+      if (!result)
         return;
       if (result[0] !== undefined)
         output.push(result[0]);
@@ -121,6 +128,7 @@
   internal.parsing.NUMBER_REGEX_STR = numberValueRegexStr;
   internal.parsing.isNumberValueString = isNumberValueString;
   internal.parsing.ignore = ignore;
+  internal.parsing.optional = optional;
   internal.parsing.consumeToken = consumeToken;
   internal.parsing.consumeNumber = consumeNumber;
   internal.parsing.consumeTrimmed = consumeTrimmed;

--- a/target-config.js
+++ b/target-config.js
@@ -26,6 +26,7 @@
       // CSSTransformComponent and subclasses
       'src/css-transform-component.js',
       'src/css-matrix.js',
+      'src/css-matrix-parsing.js',
       'src/css-perspective.js',
       'src/css-rotation.js',
       'src/css-scale.js',

--- a/test/js/css-matrix.js
+++ b/test/js/css-matrix.js
@@ -19,4 +19,53 @@ suite('CSSMatrix', function() {
     assert.strictEqual(matrix2d.cssText, 'matrix(1, 2, 3, 4, 5, 6)');
     assert.strictEqual(matrix3d.cssText, 'matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16)');
   });
+
+  test('Parsing matrices', function() {
+    var values = [
+    {
+      str: 'matrix(1,2,3,4,5,.6)',
+      matrix: new DOMMatrixReadonly([1, 2, 3, 4, 5, 0.6]),
+      remaining: ''
+    },
+    {
+      str: 'matrix3d(1, 2, 3, 4, 5, 6, 7, 8.6, 9, 10, 11, 12, 13, 14, 15, 16)',
+      matrix: new DOMMatrixReadonly([1, 2, 3, 4, 5, 6, 7, 8.6, 9, 10, 11, 12, 13, 14, 15, 16]),
+      remaining: ''
+    },
+    // Parsing should be case insensitive. Trailing characters should be returned.
+    {
+      str: 'MatRiX(1,2,3,4,5,6)abc',
+      matrix: new DOMMatrixReadonly([1,2,3,4,5,6]),
+      remaining: 'abc'
+    },
+    {
+      str: 'matrIx3D(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) 124',
+      matrix: new DOMMatrixReadonly([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]),
+      remaining: '124'
+    }];
+    for (var i = 0; i < values.length; i++) {
+      var result = typedOM.internal.parsing.consumeMatrix(values[i].str);
+      assert.isNotNull(result, values[i].str + ' should parse into a CSSMatrix');
+      assert.instanceOf(result[0], CSSMatrix);
+      assert.strictEqual(result[1], values[i].remaining);
+      typedOM.internal.testing.matricesApproxEqual(result[0].matrix, values[i].matrix);
+    }
+  });
+
+  test('Parsing matrices fails with invalid strings', function() {
+    assert.isNull(typedOM.internal.parsing.consumeMatrix(''));
+    assert.isNull(typedOM.internal.parsing.consumeMatrix('bananas'));
+    // Missing characters
+    assert.isNull(typedOM.internal.parsing.consumeMatrix('matrix(1,2,3,4,5,6'));
+    assert.isNull(typedOM.internal.parsing.consumeMatrix('matri(1,2,3,4,5,6)'));
+    assert.isNull(typedOM.internal.parsing.consumeMatrix('matrix3(1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16)'));
+    assert.isNull(typedOM.internal.parsing.consumeMatrix('matrix3d(1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16'));
+    // Incorrect number of numbers
+    assert.isNull(typedOM.internal.parsing.consumeMatrix('matrix()'));
+    assert.isNull(typedOM.internal.parsing.consumeMatrix('matrix(1,2,3,4,5,6,7)'));
+    assert.isNull(typedOM.internal.parsing.consumeMatrix('matrix(1,2,3,4,5)'));
+    assert.isNull(typedOM.internal.parsing.consumeMatrix('matrix3d()'));
+    assert.isNull(typedOM.internal.parsing.consumeMatrix('matrix3d(1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17)'));
+    assert.isNull(typedOM.internal.parsing.consumeMatrix('matrix3d(1,2,3,4,5,6,7,8,9,10,11,12,13,14,15)'));
+  });
 });


### PR DESCRIPTION
Added a `parsing.optional` method which can be used with consumeList to bring in optional arguments (in this case the "3d" part of matrix/matrix3d).
