### PR TITLE
Add parsing for CSSPerspective

### DIFF
--- a/src/css-length-value-parsing.js
+++ b/src/css-length-value-parsing.js
@@ -26,7 +26,7 @@
     // lowercase) to prevent problems with types which are substrings of
     // each other (although prefixes may be problematic!)
     var matchedUnits = {};
-    string = string.replace(new RegExp(unitRegExpStr, 'g'), function(match) {
+    string = string.replace(new RegExp(unitRegExpStr, 'gi'), function(match) {
       matchedUnits[match] = null;
       return 'U' + match;
     });
@@ -97,7 +97,7 @@
     if (!consumedNumber) {
       return;
     }
-    var unitRegExp = new RegExp('^' + unitRegExpStr, 'g');
+    var unitRegExp = new RegExp('^' + unitRegExpStr, 'gi');
     var consumedUnit = internal.parsing.consumeToken(unitRegExp, consumedNumber[1]);
     if (!consumedUnit) {
       if (consumedNumber[0] == 0) {
@@ -120,7 +120,6 @@
     }
 
     // Consume until balanced closing parens
-    var unitRegExp = new RegExp('^' + unitRegExpStr, 'g');
     var result = internal.parsing.consumeParenthesised(
         parseDimension, consumedCalcToken[1]);
     if (!result) {
@@ -138,6 +137,6 @@
     return consumeSimpleLength(str);
   }
 
-
+  internal.parsing.consumeSimpleLength = consumeSimpleLength;
   internal.parsing.consumeLengthValue = consumeLengthValue;
 })(typedOM.internal);

--- a/src/css-perspective-parsing.js
+++ b/src/css-perspective-parsing.js
@@ -1,0 +1,41 @@
+// Copyright 2016 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//     You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//     See the License for the specific language governing permissions and
+// limitations under the License.
+
+(function(internal) {
+  var parsing = internal.parsing;
+
+  function consumePerspective(string) {
+    var params = parsing.consumeList([
+        parsing.ignore(parsing.consumeToken.bind(null, /^perspective/i)),
+        parsing.ignore(parsing.consumeToken.bind(null, /^\(/)),
+        parsing.consumeSimpleLength,
+        parsing.ignore(parsing.consumeToken.bind(null, /^\)/))
+    ], string);
+    if (!params) {
+      return null;
+    }
+
+    var length = params[0][0];
+    var remaining = params[1];
+
+    if (length.type !== 'px') {
+      return null;
+    }
+
+    return [new CSSPerspective(length), remaining];
+  }
+
+  internal.parsing.consumePerspective = consumePerspective;
+
+})(typedOM.internal);

--- a/src/css-transform-component-parsing.js
+++ b/src/css-transform-component-parsing.js
@@ -35,7 +35,7 @@
 
   var transformFunctions = {
     'matrix': consumeMatrix,
-    'perspective': consumePerspective,
+    'perspective': internal.parsing.consumePerspective,
     'rotate': consumeRotation,
     'scale': consumeScale,
     'skew': consumeSkew,

--- a/src/css-transform-component-parsing.js
+++ b/src/css-transform-component-parsing.js
@@ -18,9 +18,6 @@
   function consumeMatrix(string) {
   }
 
-  function consumePerspective(string) {
-  }
-
   function consumeRotation(string) {
   }
 

--- a/target-config.js
+++ b/target-config.js
@@ -23,6 +23,17 @@
       // Utility functions.
       'src/util.js',
       'src/parsing.js',
+      // CSSTransformComponent and subclasses
+      'src/css-transform-component.js',
+      'src/css-matrix.js',
+      'src/css-matrix-parsing.js',
+      'src/css-perspective.js',
+      'src/css-perspective-parsing.js',
+      'src/css-rotation.js',
+      'src/css-rotation-parsing.js',
+      'src/css-scale.js',
+      'src/css-skew.js',
+      'src/css-translation.js',
       // CSSStyleValue and subclasses
       'src/css-style-value.js',
       'src/css-angle-value.js',
@@ -44,17 +55,6 @@
       'src/css-position-value-parsing.js',
       // Depends on both transform component subclasses and length parsing.
       'src/css-transform-component-parsing.js',
-      // CSSTransformComponent and subclasses
-      'src/css-transform-component.js',
-      'src/css-matrix.js',
-      'src/css-matrix-parsing.js',
-      'src/css-perspective.js',
-      'src/css-perspective-parsing.js',
-      'src/css-rotation.js',
-      'src/css-rotation-parsing.js',
-      'src/css-scale.js',
-      'src/css-skew.js',
-      'src/css-translation.js',
       // Other stuff.
       'src/dom-matrix-readonly.js',
       'src/style-property-map-readonly.js',

--- a/target-config.js
+++ b/target-config.js
@@ -23,16 +23,6 @@
       // Utility functions.
       'src/util.js',
       'src/parsing.js',
-      // CSSTransformComponent and subclasses
-      'src/css-transform-component.js',
-      'src/css-matrix.js',
-      'src/css-matrix-parsing.js',
-      'src/css-perspective.js',
-      'src/css-rotation.js',
-      'src/css-rotation-parsing.js',
-      'src/css-scale.js',
-      'src/css-skew.js',
-      'src/css-translation.js',
       // CSSStyleValue and subclasses
       'src/css-style-value.js',
       'src/css-angle-value.js',
@@ -54,6 +44,17 @@
       'src/css-position-value-parsing.js',
       // Depends on both transform component subclasses and length parsing.
       'src/css-transform-component-parsing.js',
+      // CSSTransformComponent and subclasses
+      'src/css-transform-component.js',
+      'src/css-matrix.js',
+      'src/css-matrix-parsing.js',
+      'src/css-perspective.js',
+      'src/css-perspective-parsing.js',
+      'src/css-rotation.js',
+      'src/css-rotation-parsing.js',
+      'src/css-scale.js',
+      'src/css-skew.js',
+      'src/css-translation.js',
       // Other stuff.
       'src/dom-matrix-readonly.js',
       'src/style-property-map-readonly.js',

--- a/test/js/css-length-value.js
+++ b/test/js/css-length-value.js
@@ -56,6 +56,21 @@ suite('CSSLengthValue', function() {
       {str: '.7px', out: new CSSSimpleLength(0.7, 'px')},
       {str: '10e3px', out: new CSSSimpleLength(10e3, 'px')},
       {str: '-3.4e-2px', out: new CSSSimpleLength(-3.4e-2, 'px')},
+      // Case for units.
+      {str: '1PX', out: new CSSSimpleLength(1, 'px')},
+      {str: '3EM', out: new CSSSimpleLength(3, 'em')},
+      {str: '4EX', out: new CSSSimpleLength(4, 'ex')},
+      {str: '6CH', out: new CSSSimpleLength(6, 'ch')},
+      {str: '7REM', out: new CSSSimpleLength(7, 'rem')},
+      {str: '8VW', out: new CSSSimpleLength(8, 'vw')},
+      {str: '9VH', out: new CSSSimpleLength(9, 'vh')},
+      {str: '10VMIN', out: new CSSSimpleLength(10, 'vmin')},
+      {str: '11VMAX', out: new CSSSimpleLength(11, 'vmax')},
+      {str: '12CM', out: new CSSSimpleLength(12, 'cm')},
+      {str: '13MM', out: new CSSSimpleLength(13, 'mm')},
+      {str: '14IN', out: new CSSSimpleLength(14, 'in')},
+      {str: '15PC', out: new CSSSimpleLength(15, 'pc')},
+      {str: '16PT', out: new CSSSimpleLength(16, 'pt')},
     ];
 
     for (var i = 0; i < values.length; i++) {

--- a/test/js/css-perspective.js
+++ b/test/js/css-perspective.js
@@ -38,4 +38,19 @@ suite('CSSPerspective', function() {
     var expectedMatrix = new DOMMatrixReadonly([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, -0.1, 0, 0, 0, 1]);
     typedOM.internal.testing.matricesApproxEqual(perspective.matrix, expectedMatrix);
   });
+
+  test('Parsing valid strings results in correct values', function() {
+    var values = [
+      {str: 'perspective(2.6px)', l: new CSSSimpleLength(2.6, 'px'), remaining: ''}, 
+      {str: 'PERSPECTIVE(2.6PX) bananas', l: new CSSSimpleLength(2.6, 'px'), remaining: 'bananas'}, 
+    ]
+    for (var i = 0; i < values.length; i++) {
+      var parsed = typedOM.internal.parsing.consumePerspective(values[i].str);
+      assert.isNotNull(parsed, values[i].str + ' should parse a CSSPerspective');
+      assert.strictEqual(parsed[1], values[i].remaining);
+      assert.instanceOf(parsed[0], CSSPerspective);
+      assert.strictEqual(parsed[0].length.value, values[i].l.value);
+      assert.strictEqual(parsed[0].length.type, values[i].l.type);
+    }
+  });
 });

--- a/test/js/css-perspective.js
+++ b/test/js/css-perspective.js
@@ -53,4 +53,18 @@ suite('CSSPerspective', function() {
       assert.strictEqual(parsed[0].length.type, values[i].l.type);
     }
   });
+
+  test('Parsing invalid strings results in null', function() {
+    var consumePerspective = typedOM.internal.parsing.consumePerspective;
+    assert.isNull(consumePerspective(''));
+    assert.isNull(consumePerspective('bananas'));
+    assert.isNull(consumePerspective('perspective()'));
+    assert.isNull(consumePerspective('perspective(5)')); // Missing unit.
+    assert.isNull(consumePerspective('perspective(5ab)')); // Invalid unit.
+    // Valid length unit that is invalid for perspective.
+    assert.isNull(consumePerspective('perspective(5%)'));
+    assert.isNull(consumePerspective('perspective(5px, 6px)')); // Too many args.
+    assert.isNull(consumePerspective('perspective(5px')); // Missing bracket.
+    assert.isNull(consumePerspective('perspectiveY(5px)')); // Invalid keyword.
+  });
 });


### PR DESCRIPTION
Also expose consumeSimpleLength, and make sure consumeSimpleLength's unit parsing is not case-sensitive.
