### PR TITLE
Make CSSSkew work with CSSAngleValue arguments

### DIFF
--- a/src/css-angle-value.js
+++ b/src/css-angle-value.js
@@ -86,7 +86,7 @@
         break;
     }
 
-    this.cssString = this._value + this._unit;
+    this.cssText = this._value + this._unit;
   }
   internal.inherit(CSSAngleValue, CSSStyleValue);
 

--- a/src/css-rotation.js
+++ b/src/css-rotation.js
@@ -54,12 +54,12 @@
   function generateCssString(cssRotation) {
     var cssText;
     if (cssRotation.is2D) {
-      cssText = 'rotate(' + cssRotation.angle + 'deg)';
+      cssText = 'rotate(' + cssRotation._angle.cssText + ')';
     } else {
       cssText = 'rotate3d(' + cssRotation.x +
           ', ' + cssRotation.y +
           ', ' + cssRotation.z +
-          ', ' + cssRotation.angle + 'deg)';
+          ', ' + cssRotation._angle.cssText + ')';
     }
     return cssText;
   };
@@ -86,7 +86,13 @@
     this.y = this.is2D ? null : y;
     this.z = this.is2D ? null : z;
     var angleValue = this.is2D ? x : angle;
-    this.angle = angleValue instanceof CSSAngleValue ? angleValue.degrees : angleValue;
+    if (angleValue instanceof CSSAngleValue) {
+      this.angle = angleValue.degrees;
+      this._angle = angleValue;
+    } else {
+      this.angle = angleValue;
+      this._angle = new CSSAngleValue(angleValue, 'deg');
+    }
 
     this.matrix = computeMatrix(this);
     this.cssText = generateCssString(this);

--- a/src/css-skew-parsing.js
+++ b/src/css-skew-parsing.js
@@ -23,11 +23,11 @@
     switch (type) {
       case 'x':
         var result = [new CSSSkew(angles[0], zeroAngle), remaining];
-        result[0].cssText = 'skewx(' + result[0]._ax.cssText + ')';
+        result[0]._inputType = 'x';
         return result;
       case 'y':
         var result = [new CSSSkew(zeroAngle, angles[0]), remaining];
-        result[0].cssText = 'skewy(' + result[0]._ay.cssText + ')';
+        result[0]._inputType = 'y';
         return result;
     }
   }
@@ -54,12 +54,12 @@
 
     if (angles.length == 1) {
       var result = [new CSSSkew(angles[0], new CSSAngleValue(0, 'deg')), remaining];
-      result[0].cssText = 'skew(' + result[0]._ax.cssText + ')';
+      result[0]._inputType = '1';
       return result;
     }
     if (angles.length == 2) {
       var result = [new CSSSkew(angles[0], angles[1]), remaining];
-      result[0].cssText = 'skew(' + result[0]._ax.cssText + ', ' + result[0]._ay.cssText + ')';
+      result[0]._inputType = '2';
       return result;
     }
     return null;

--- a/src/css-skew-parsing.js
+++ b/src/css-skew-parsing.js
@@ -47,10 +47,10 @@
       return skewXorY(type, angles, remaining);
     }
     if (angles.length == 1) {
-      return [new CSSSkew(angles[0].degrees, 0), remaining];
+      return [new CSSSkew(angles[0], new CSSAngleValue(0, 'deg')), remaining];
     }
     if (angles.length == 2) {
-      return [new CSSSkew(angles[0].degrees, angles[1].degrees), remaining];
+      return [new CSSSkew(angles[0], angles[1]), remaining];
     }
     return null;
   }

--- a/src/css-skew-parsing.js
+++ b/src/css-skew-parsing.js
@@ -15,6 +15,23 @@
 (function(internal) {
   var parsing = internal.parsing;
 
+  function skewXorY(type, angles, remaining) {
+    if (angles.length != 1) {
+      return null;
+    }
+    var zeroAngle = new CSSAngleValue(0, 'deg');
+    switch (type) {
+      case 'x':
+        var result = [new CSSSkew(angles[0], zeroAngle), remaining];
+        result[0].cssText = 'skewx(' + result[0]._ax.cssText + ')';
+        return result;
+      case 'y':
+        var result = [new CSSSkew(zeroAngle, angles[0]), remaining];
+        result[0].cssText = 'skewy(' + result[0]._ay.cssText + ')';
+        return result;
+    }
+  }
+
   function consumeSkew(string) {
     var params = parsing.consumeList([
         parsing.ignore(parsing.consumeToken.bind(null, /^skew/i)),
@@ -31,25 +48,12 @@
     var type = params[0][0];
     var angles = params[0][1];
 
-    var zeroAngle = new CSSAngleValue(0, 'deg');
     if (type == 'x' || type == 'y') {
-      if (angles.length != 1) {
-        return null;
-      }
-      switch (type) {
-        case 'x':
-          var result = [new CSSSkew(angles[0], zeroAngle), remaining];
-          result[0].cssText = 'skewx(' + result[0]._ax.cssText + ')';
-          return result;
-        case 'y':
-          var result = [new CSSSkew(zeroAngle, angles[0]), remaining];
-          result[0].cssText = 'skewy(' + result[0]._ay.cssText + ')';
-          return result;
-      }
+      return skewXorY(type, angles, remaining);
     }
 
     if (angles.length == 1) {
-      var result = [new CSSSkew(angles[0], zeroAngle), remaining];
+      var result = [new CSSSkew(angles[0], new CSSAngleValue(0, 'deg')), remaining];
       result[0].cssText = 'skew(' + result[0]._ax.cssText + ')';
       return result;
     }

--- a/src/css-skew-parsing.js
+++ b/src/css-skew-parsing.js
@@ -15,22 +15,6 @@
 (function(internal) {
   var parsing = internal.parsing;
 
-  function skewXorY(type, angles, remaining, string) {
-    if (angles.length != 1) {
-      return null;
-    }
-    switch (type) {
-      case 'x':
-        var result = [new CSSSkew(angles[0], new CSSAngleValue(0, 'deg')), remaining];
-        result[0].cssText = 'skewx' + '(' + result[0]._ax.cssText + ')';
-        return result;
-      case 'y':
-        var result = [new CSSSkew(new CSSAngleValue(0, 'deg'), angles[0]), remaining];
-        result[0].cssText = 'skewy' + '(' + result[0]._ay.cssText + ')';
-        return result;
-    }
-  }
-
   function consumeSkew(string) {
     var params = parsing.consumeList([
         parsing.ignore(parsing.consumeToken.bind(null, /^skew/i)),
@@ -42,23 +26,36 @@
     if (!params) {
       return null;
     }
-    string = string.toLowerCase();
 
     var remaining = params[1];
     var type = params[0][0];
     var angles = params[0][1];
 
+    var zeroAngle = new CSSAngleValue(0, 'deg');
     if (type == 'x' || type == 'y') {
-      return skewXorY(type, angles, remaining, string);
+      if (angles.length != 1) {
+        return null;
+      }
+      switch (type) {
+        case 'x':
+          var result = [new CSSSkew(angles[0], zeroAngle), remaining];
+          result[0].cssText = 'skewx(' + result[0]._ax.cssText + ')';
+          return result;
+        case 'y':
+          var result = [new CSSSkew(zeroAngle, angles[0]), remaining];
+          result[0].cssText = 'skewy(' + result[0]._ay.cssText + ')';
+          return result;
+      }
     }
+
     if (angles.length == 1) {
-      var result = [new CSSSkew(angles[0], new CSSAngleValue(0, 'deg')), remaining];
-      result[0].cssText = 'skew' + '(' + result[0]._ax.cssText + ')';
+      var result = [new CSSSkew(angles[0], zeroAngle), remaining];
+      result[0].cssText = 'skew(' + result[0]._ax.cssText + ')';
       return result;
     }
     if (angles.length == 2) {
       var result = [new CSSSkew(angles[0], angles[1]), remaining];
-      result[0].cssText = 'skew' + '(' + result[0]._ax.cssText + ', ' + result[0]._ay.cssText + ')';
+      result[0].cssText = 'skew(' + result[0]._ax.cssText + ', ' + result[0]._ay.cssText + ')';
       return result;
     }
     return null;

--- a/src/css-skew-parsing.js
+++ b/src/css-skew-parsing.js
@@ -15,15 +15,19 @@
 (function(internal) {
   var parsing = internal.parsing;
 
-  function skewXorY(type, angles, remaining) {
+  function skewXorY(type, angles, remaining, string) {
     if (angles.length != 1) {
       return null;
     }
     switch (type) {
       case 'x':
-        return [new CSSSkew(angles[0].degrees, 0), remaining];
+        var result = [new CSSSkew(angles[0], new CSSAngleValue(0, 'deg')), remaining];
+        result[0].cssText = 'skewx' + '(' + result[0]._ax.cssText + ')';
+        return result;
       case 'y':
-        return [new CSSSkew(0, angles[0].degrees), remaining];
+        var result = [new CSSSkew(new CSSAngleValue(0, 'deg'), angles[0]), remaining];
+        result[0].cssText = 'skewy' + '(' + result[0]._ay.cssText + ')';
+        return result;
     }
   }
 
@@ -38,19 +42,24 @@
     if (!params) {
       return null;
     }
+    string = string.toLowerCase();
 
     var remaining = params[1];
     var type = params[0][0];
     var angles = params[0][1];
 
     if (type == 'x' || type == 'y') {
-      return skewXorY(type, angles, remaining);
+      return skewXorY(type, angles, remaining, string);
     }
     if (angles.length == 1) {
-      return [new CSSSkew(angles[0], new CSSAngleValue(0, 'deg')), remaining];
+      var result = [new CSSSkew(angles[0], new CSSAngleValue(0, 'deg')), remaining];
+      result[0].cssText = 'skew' + '(' + result[0]._ax.cssText + ')';
+      return result;
     }
     if (angles.length == 2) {
-      return [new CSSSkew(angles[0], angles[1]), remaining];
+      var result = [new CSSSkew(angles[0], angles[1]), remaining];
+      result[0].cssText = 'skew' + '(' + result[0]._ax.cssText + ', ' + result[0]._ay.cssText + ')';
+      return result;
     }
     return null;
   }

--- a/src/css-skew.js
+++ b/src/css-skew.js
@@ -55,16 +55,19 @@
 
     this.matrix = computeMatrix(this);
     this.is2D = this.matrix.is2D;
-  }
 
-  Object.defineProperty(CSSSkew.prototype, 'cssText', {
-    get: function() {
-      if (!this.cssText) {
-        this.cssText = generateCssString(this);
+    Object.defineProperty(this, 'cssText', {
+      get: function() {
+        if (!this._cssText) {
+          this._cssText = generateCssString(this);
+        }
+        return this._cssText;
+      },
+      set: function(newCssText) {
+        this._cssText = newCssText;
       }
-      return this.cssText;
-    }
-  });
+    });
+  }
 
   internal.inherit(CSSSkew, internal.CSSTransformComponent);
 

--- a/src/css-skew.js
+++ b/src/css-skew.js
@@ -36,22 +36,20 @@
   function CSSSkew(ax, ay) {
     if (arguments.length != 2) {
       throw new TypeError('CSSSkew must have 2 arguments.');
-    } else if ((typeof ax != 'number' && !(ax instanceof CSSAngleValue)) || (typeof ay != 'number' && !(ay instanceof CSSAngleValue))) {
-      throw new TypeError('CSSSkew arguments must be a number or a CSSAngleValue.');
+    // Arguments must both be CSSAngleValues or both be doubles.
+    } else if (!(ay instanceof CSSAngleValue && ax instanceof CSSAngleValue) && !(typeof ay == 'number' && typeof ax == 'number')) {
+      throw new TypeError('CSSSkew arguments must be all numbers or all CSSAngleValues.');
     }
 
     if (ax instanceof CSSAngleValue) {
       this.ax = ax.degrees;
-      this._ax = ax;
-    } else {
-      this.ax = ax;
-      this._ax = new CSSAngleValue(ax, 'deg');
-    }
-    if (ay instanceof CSSAngleValue) {
       this.ay = ay.degrees;
+      this._ax = ax;
       this._ay = ay;
     } else {
+      this.ax = ax;
       this.ay = ay;
+      this._ax = new CSSAngleValue(ax, 'deg');
       this._ay = new CSSAngleValue(ay, 'deg');
     }
 

--- a/src/css-skew.js
+++ b/src/css-skew.js
@@ -55,8 +55,17 @@
 
     this.matrix = computeMatrix(this);
     this.is2D = this.matrix.is2D;
-    this.cssText = generateCssString(this);
   }
+
+  Object.defineProperty(CSSSkew.prototype, 'cssText', {
+    get: function() {
+      if (!this.cssText) {
+        this.cssText = generateCssString(this);
+      }
+      return this.cssText;
+    }
+  });
+
   internal.inherit(CSSSkew, internal.CSSTransformComponent);
 
   scope.CSSSkew = CSSSkew;

--- a/src/css-skew.js
+++ b/src/css-skew.js
@@ -36,12 +36,12 @@
   function CSSSkew(ax, ay) {
     if (arguments.length != 2) {
       throw new TypeError('CSSSkew must have 2 arguments.');
-    } else if (typeof ax != 'number' || typeof ay != 'number') {
-      throw new TypeError('CSSSkew arguments must be of type \'number\'.');
+    } else if ((typeof ax != 'number' && !(ax instanceof CSSAngleValue)) || (typeof ay != 'number' && !(ay instanceof CSSAngleValue))) {
+      throw new TypeError('CSSSkew arguments must be a number or a CSSAngleValue.');
     }
 
-    this.ax = ax;
-    this.ay = ay;
+    this.ax = (typeof ax == 'number') ? ax : ax.degrees;
+    this.ay = (typeof ay == 'number') ? ay : ay.degrees;
 
     this.matrix = computeMatrix(this);
     this.is2D = this.matrix.is2D;

--- a/src/css-skew.js
+++ b/src/css-skew.js
@@ -30,7 +30,16 @@
   };
 
   function generateCssString(cssSkew) {
-    return 'skew(' + cssSkew._ax.cssText + ', ' + cssSkew._ay.cssText + ')';
+    switch (cssSkew._inputType) {
+      case '1':
+        return 'skew(' + cssSkew._ax.cssText + ')';
+      case '2':
+        return 'skew(' + cssSkew._ax.cssText + ', ' + cssSkew._ay.cssText + ')';
+      case 'x':
+        return 'skewx(' + cssSkew._ax.cssText + ')';
+      case 'y':
+        return 'skewy(' + cssSkew._ay.cssText + ')';
+    }
   };
 
   function CSSSkew(ax, ay) {
@@ -55,6 +64,7 @@
 
     this.matrix = computeMatrix(this);
     this.is2D = this.matrix.is2D;
+    this._inputType = '2';
 
     Object.defineProperty(this, 'cssText', {
       get: function() {
@@ -63,9 +73,7 @@
         }
         return this._cssText;
       },
-      set: function(newCssText) {
-        this._cssText = newCssText;
-      }
+      set: function(newCssText) {}
     });
   }
 

--- a/src/css-skew.js
+++ b/src/css-skew.js
@@ -30,7 +30,7 @@
   };
 
   function generateCssString(cssSkew) {
-    return 'skew(' + cssSkew.ax + 'deg' + ', ' + cssSkew.ay + 'deg' + ')';
+    return 'skew(' + cssSkew._ax.cssText + ', ' + cssSkew._ay.cssText + ')';
   };
 
   function CSSSkew(ax, ay) {
@@ -40,8 +40,20 @@
       throw new TypeError('CSSSkew arguments must be a number or a CSSAngleValue.');
     }
 
-    this.ax = (typeof ax == 'number') ? ax : ax.degrees;
-    this.ay = (typeof ay == 'number') ? ay : ay.degrees;
+    if (ax instanceof CSSAngleValue) {
+      this.ax = ax.degrees;
+      this._ax = ax;
+    } else {
+      this.ax = ax;
+      this._ax = new CSSAngleValue(ax, 'deg');
+    }
+    if (ay instanceof CSSAngleValue) {
+      this.ay = ay.degrees;
+      this._ay = ay;
+    } else {
+      this.ay = ay;
+      this._ay = new CSSAngleValue(ay, 'deg');
+    }
 
     this.matrix = computeMatrix(this);
     this.is2D = this.matrix.is2D;

--- a/test/js/css-angle-value.js
+++ b/test/js/css-angle-value.js
@@ -2,6 +2,22 @@ suite('CSSAngleValue', function() {
 
 var EPSILON = 1e-6;
 
+test('CSSAngleValue constructor works for valid arguments', function() {
+  var values = [
+    {angle: new CSSAngleValue(1.1, 'deg'), degrees: 1.1, value: 1.1, unit: 'deg', cssText: '1.1deg'},
+    {angle: new CSSAngleValue(-2, 'rad'), degrees: -114.591559, value: -2, unit: 'rad', cssText: '-2rad'},
+    {angle: new CSSAngleValue(3.0003, 'grad'), degrees: 2.700270, value: 3.0003, unit: 'grad', cssText: '3.0003grad'},
+    {angle: new CSSAngleValue(400, 'turn'), degrees: 144000, value: 400, unit: 'turn', cssText: '400turn'},
+  ];
+  for (var i = 0; i < values.length; i++) {
+    assert.instanceOf(values[i].angle, CSSAngleValue);
+    assert.approximately(values[i].angle.degrees, values[i].degrees, EPSILON);
+    assert.strictEqual(values[i].angle._value, values[i].value);
+    assert.strictEqual(values[i].angle._unit, values[i].unit);
+    assert.strictEqual(values[i].angle.cssText, values[i].cssText);
+  }
+});
+
 test('Wrong number of arguments throws', function() {
   assert.throw(function() { new CSSAngleValue(); }, TypeError, 'Must specify an angle and a unit');
   assert.throw(function() { new CSSAngleValue(5); }, TypeError, 'Must specify an angle and a unit');
@@ -54,31 +70,37 @@ test('Conversions when specified as turns', function() {
 
 test('Parsing valid strings results in expected CSSAngleValues', function() {
   var values = [
-    {str: '1.1deg', value: new CSSAngleValue(1.1, 'deg')},
-    {str: '-2rad', value: new CSSAngleValue(-2, 'rad')},
-    {str: '3.0003grad', value: new CSSAngleValue(3.0003, 'grad')},
-    {str: '400turn', value: new CSSAngleValue(400, 'turn')},
+    {str: '1.1deg', degrees: 1.1, value: 1.1, unit: 'deg', cssText: '1.1deg'},
+    {str: '-2rad', degrees: -114.591559, value: -2, unit: 'rad', cssText: '-2rad'},
+    {str: '3.0003grad', degrees: 2.700270, value: 3.0003, unit: 'grad', cssText: '3.0003grad'},
+    {str: '400turn', degrees: 144000, value: 400, unit: 'turn', cssText: '400turn'},
   ];
   for (var i = 0; i < values.length; i++) {
     var result = typedOM.internal.parsing.consumeAngleValue(values[i].str);
     assert.isNotNull(result, 'Failed parsing ' + values[i].str);
     assert.instanceOf(result[0], CSSAngleValue);
-    assert.strictEqual(result[0].deg, values[i].value.deg);
+    assert.approximately(result[0].degrees, values[i].degrees, EPSILON);
+    assert.strictEqual(result[0]._value, values[i].value);
+    assert.strictEqual(result[0]._unit, values[i].unit);
+    assert.strictEqual(result[0].cssText, values[i].cssText);
   }
 });
 
 test('Parsing is case insensitive', function() {
   var values = [
-    {str: '1.1DEG', value: new CSSAngleValue(1.1, 'deg')},
-    {str: '-2rAd', value: new CSSAngleValue(-2, 'rad')},
-    {str: '3.0003GrAd', value: new CSSAngleValue(3.0003, 'grad')},
-    {str: '400tuRN', value: new CSSAngleValue(400, 'turn')},
+    {str: '1.1DEG', degrees: 1.1, value: 1.1, unit: 'deg', cssText: '1.1deg'},
+    {str: '-2rAd', degrees: -114.591559, value: -2, unit: 'rad', cssText: '-2rad'},
+    {str: '3.0003GrAd', degrees: 2.700270, value: 3.0003, unit: 'grad', cssText: '3.0003grad'},
+    {str: '400tuRN', degrees: 144000, value: 400, unit: 'turn', cssText: '400turn'},
   ];
   for (var i = 0; i < values.length; i++) {
     var result = typedOM.internal.parsing.consumeAngleValue(values[i].str);
     assert.isNotNull(result, 'Failed parsing ' + values[i].str);
     assert.instanceOf(result[0], CSSAngleValue);
-    assert.strictEqual(result[0].deg, values[i].value.deg);
+    assert.approximately(result[0].degrees, values[i].degrees, EPSILON);
+    assert.strictEqual(result[0]._value, values[i].value);
+    assert.strictEqual(result[0]._unit, values[i].unit);
+    assert.strictEqual(result[0].cssText, values[i].cssText);
   }
 });
 

--- a/test/js/css-skew.js
+++ b/test/js/css-skew.js
@@ -15,12 +15,12 @@ suite('CSSSkew', function() {
 
   test('CSSSkew constructor works correctly', function() {
     var values = [
-    {skew: new CSSSkew(30, 180), cssTextExpected: 'skew(30deg, 180deg)'},
-    {skew: new CSSSkew(new CSSAngleValue(30, 'deg'), new CSSAngleValue(180, 'deg')), cssTextExpected: 'skew(30deg, 180deg)'},
-    {skew: new CSSSkew(new CSSAngleValue(0.52359878, 'rad'), new CSSAngleValue(3.14159265, 'rad')), cssTextExpected: 'skew(0.52359878rad, 3.14159265rad)'}];
+    {skew: new CSSSkew(30, 180), cssText: 'skew(30deg, 180deg)'},
+    {skew: new CSSSkew(new CSSAngleValue(30, 'deg'), new CSSAngleValue(180, 'deg')), cssText: 'skew(30deg, 180deg)'},
+    {skew: new CSSSkew(new CSSAngleValue(0.52359878, 'rad'), new CSSAngleValue(3.14159265, 'rad')), cssText: 'skew(0.52359878rad, 3.14159265rad)'}];
     var expectedMatrix = new DOMMatrixReadonly([1, 0, 0.577350, 1, 0, 0]);
     for (var i = 0; i < values.length; i++) {
-      assert.strictEqual(values[i].skew.cssText, values[i].cssTextExpected);
+      assert.strictEqual(values[i].skew.cssText, values[i].cssText);
       assert.closeTo(values[i].skew.ax, 30, 1e-6);
       assert.closeTo(values[i].skew.ay, 180, 1e-6);
       assert.isTrue(values[i].skew.is2D);

--- a/test/js/css-skew.js
+++ b/test/js/css-skew.js
@@ -1,10 +1,4 @@
 suite('CSSSkew', function() {
-  test('CSSSkew is a CSSSkew and CSSTransformComponent', function() {
-    var skew = new CSSSkew(1, 2);
-    assert.instanceOf(skew, CSSSkew, 'A new CSSSkew should be an instance of CSSSkew');
-    assert.instanceOf(skew, typedOM.internal.CSSTransformComponent,
-        'A new CSSSkew should be an instance of CSSTransformComponent');
-  });
 
   test('CSSSkew constructor throws exception for invalid types', function() {
     assert.throws(function() {new CSSSkew()});
@@ -17,15 +11,18 @@ suite('CSSSkew', function() {
   });
 
   test('CSSSkew constructor works correctly', function() {
-    var skew;
-    assert.doesNotThrow(function() {skew = new CSSSkew(30, 180)});
-    assert.strictEqual(skew.cssText, 'skew(30deg, 180deg)');
-    assert.strictEqual(skew.ax, 30);
-    assert.strictEqual(skew.ay, 180);
-    assert.isTrue(skew.is2D);
-
+    var values = [
+    {skew: new CSSSkew(30, 180), cssTextExpected: 'skew(30deg, 180deg)'},
+    {skew: new CSSSkew(new CSSAngleValue(30, 'deg'), new CSSAngleValue(180, 'deg')), cssTextExpected: 'skew(30deg, 180deg)'},
+    {skew: new CSSSkew(new CSSAngleValue(0.52359878, 'rad'), new CSSAngleValue(3.14159265, 'rad')), cssTextExpected: 'skew(0.52359878rad, 3.14159265rad)'}];
     var expectedMatrix = new DOMMatrixReadonly([1, 0, 0.577350, 1, 0, 0]);
-    typedOM.internal.testing.matricesApproxEqual(skew.matrix, expectedMatrix);
+    for (var i = 0; i < values.length; i++) {
+      assert.strictEqual(values[i].skew.cssText, values[i].cssTextExpected);
+      assert.closeTo(values[i].skew.ax, 30, 1e-6);
+      assert.closeTo(values[i].skew.ay, 180, 1e-6);
+      assert.isTrue(values[i].skew.is2D);
+      typedOM.internal.testing.matricesApproxEqual(values[i].skew.matrix, expectedMatrix);
+    }
   });
 
   test('Parsing valid strings results in CSSSkew with correct values', function() {

--- a/test/js/css-skew.js
+++ b/test/js/css-skew.js
@@ -30,22 +30,22 @@ suite('CSSSkew', function() {
 
   test('Parsing valid strings results in CSSSkew with correct values', function() {
     var values = [
-      {str: 'skew(45deg)', x: 45, y: 0, remaining: ''}, // skew with 1 arg
-      {str: 'skew(5rad)', x: 286.478897, y: 0, remaining: ''},
-      {str: 'skew(215grad)', x: 193.5, y: 0, remaining: ''},
-      {str: 'skew(0.6turn)', x: 216, y: 0, remaining: ''},
-      {str: 'SkeW(5dEg)', x: 5, y: 0, remaining: ''},
-      {str: 'SKEW(4DeG)', x: 4, y: 0, remaining: ''},
-      {str: 'skew(45deg))))', x: 45, y: 0, remaining: ')))'},
-      {str: 'skew(60deg, -0.2turn)', x: 60, y: -72, remaining: ''}, // skew with 2 args
-      {str: 'SkEW(0.2TURN, 1Rad)', x: 72, y: 57.295780, remaining: ''},
-      {str: 'skew(20deg, 1rad) 123', x: 20, y: 57.295780, remaining: '123'},
-      {str: 'skewx(10deg)', x: 10, y: 0, remaining: ''}, // skewx
-      {str: 'SkewX(1TuRn)', x: 360, y: 0, remaining: ''},
-      {str: 'skewx(100grad) abc', x: 90, y: 0, remaining: 'abc'},
-      {str: 'skewy(0.45turn)', x: 0, y: 162, remaining: ''}, // skewy
-      {str: 'SkEwY(2.1RAD)', x: 0, y: 120.321137, remaining: ''},
-      {str: 'skewy(20DEG))))', x: 0, y: 20, remaining: ')))'},
+      {str: 'skew(45deg)', x: 45, y: 0, cssText: 'skew(45deg)', remaining: ''}, // skew with 1 arg
+      {str: 'skew(5rad)', x: 286.478897, y: 0, cssText: 'skew(5rad)', remaining: ''},
+      {str: 'skew(215grad)', x: 193.5, y: 0, cssText: 'skew(215grad)', remaining: ''},
+      {str: 'skew(0.6turn)', x: 216, y: 0, cssText: 'skew(0.6turn)', remaining: ''},
+      {str: 'SkeW(5dEg)', x: 5, y: 0, cssText: 'skew(5deg)', remaining: ''},
+      {str: 'SKEW(4DeG)', x: 4, y: 0, cssText: 'skew(4deg)', remaining: ''},
+      {str: 'skew(45deg))))', x: 45, y: 0, cssText: 'skew(45deg)', remaining: ')))'},
+      {str: 'skew(60deg, -0.2turn)', x: 60, y: -72, cssText: 'skew(60deg, -0.2turn)', remaining: ''}, // skew with 2 args
+      {str: 'SkEW(0.2TURN, 1Rad)', x: 72, y: 57.295780, cssText: 'skew(0.2turn, 1rad)', remaining: ''},
+      {str: 'skew(20deg, 1rad) 123', x: 20, y: 57.295780, cssText: 'skew(20deg, 1rad)', remaining: '123'},
+      {str: 'skewx(10deg)', x: 10, y: 0, cssText: 'skewx(10deg)', remaining: ''}, // skewx
+      {str: 'SkewX(1TuRn)', x: 360, y: 0, cssText: 'skewx(1turn)', remaining: ''},
+      {str: 'skewx(100grad) abc', x: 90, y: 0, cssText: 'skewx(100grad)', remaining: 'abc'},
+      {str: 'skewy(0.45turn)', x: 0, y: 162, cssText: 'skewy(0.45turn)', remaining: ''}, // skewy
+      {str: 'SkEwY(2.1RAD)', x: 0, y: 120.321137, cssText: 'skewy(2.1rad)', remaining: ''},
+      {str: 'skewy(20DEG))))', x: 0, y: 20, cssText: 'skewy(20deg)', remaining: ')))'},
     ];
     for (var i = 0; i < values.length; i++) {
       var parsed = typedOM.internal.parsing.consumeSkew(values[i].str);
@@ -53,6 +53,7 @@ suite('CSSSkew', function() {
       assert.strictEqual(parsed[1], values[i].remaining, values[i].str + ' expected ' + values[i].remaining + ' as trailing characters');
       assert.instanceOf(parsed[0], CSSSkew);
       assert.isTrue(parsed[0].is2D); // Skew matrices should always be 2D
+      assert.strictEqual(parsed[0].cssText, values[i].cssText);
       assert.approximately(parsed[0].ax, values[i].x, 1e-6);
       assert.approximately(parsed[0].ay, values[i].y, 1e-6);
     }

--- a/test/js/css-skew.js
+++ b/test/js/css-skew.js
@@ -1,13 +1,16 @@
 suite('CSSSkew', function() {
 
   test('CSSSkew constructor throws exception for invalid types', function() {
-    assert.throws(function() {new CSSSkew()});
-    assert.throws(function() {new CSSSkew({})});
-    assert.throws(function() {new CSSSkew({}, {})});
-    assert.throws(function() {new CSSSkew(1)});
-    assert.throws(function() {new CSSSkew('1', '2')});
-    assert.throws(function() {new CSSSkew(3, null)});
-    assert.throws(function() {new CSSSkew(1, 2, 3)});
+    argCountErr = /^CSSSkew must have 2 arguments\./;
+    assert.throws(function() {new CSSSkew()}, TypeError, argCountErr);
+    assert.throws(function() {new CSSSkew({})}, TypeError, argCountErr);
+    assert.throws(function() {new CSSSkew(1)}, TypeError, argCountErr);
+    assert.throws(function() {new CSSSkew(1, 2, 3)}, TypeError, argCountErr);
+    var argTypeErr = /^CSSSkew arguments must be all numbers or all CSSAngleValues\./;
+    assert.throws(function() {new CSSSkew({}, {})}, TypeError, argTypeErr);
+    assert.throws(function() {new CSSSkew('1', '2')}, TypeError, argTypeErr);
+    assert.throws(function() {new CSSSkew(1, new CSSAngleValue(2, 'deg'))}, TypeError, argTypeErr);
+    assert.throws(function() {new CSSSkew(3, null)}, TypeError, argTypeErr);
   });
 
   test('CSSSkew constructor works correctly', function() {


### PR DESCRIPTION
This spec change https://github.com/w3c/css-houdini-drafts/pull/271 means we won't need to store _ax/_ay and ax/ay.

Will update cssText in other TransformComponenets in a later patch.
