### PR TITLE
Add CSSAngleValue support to CSSSkew constructor

### DIFF
--- a/src/css-rotation.js
+++ b/src/css-rotation.js
@@ -86,7 +86,13 @@
     this.y = this.is2D ? null : y;
     this.z = this.is2D ? null : z;
     var angleValue = this.is2D ? x : angle;
-    this.angle = angleValue instanceof CSSAngleValue ? angleValue.degrees : angleValue;
+    if (angleValue instanceof CSSAngleValue) {
+      this.angle = angleValue.degrees;
+      this._angle = angleValue;
+    } else {
+      this.angle = angleValue;
+      this._angle = new CSSAngleValue(angleValue, 'deg');
+    }
 
     this.matrix = computeMatrix(this);
     this.cssText = generateCssString(this);

--- a/src/css-rotation.js
+++ b/src/css-rotation.js
@@ -86,13 +86,7 @@
     this.y = this.is2D ? null : y;
     this.z = this.is2D ? null : z;
     var angleValue = this.is2D ? x : angle;
-    if (angleValue instanceof CSSAngleValue) {
-      this.angle = angleValue.degrees;
-      this._angle = angleValue;
-    } else {
-      this.angle = angleValue;
-      this._angle = new CSSAngleValue(angleValue, 'deg');
-    }
+    this.angle = angleValue instanceof CSSAngleValue ? angleValue.degrees : angleValue;
 
     this.matrix = computeMatrix(this);
     this.cssText = generateCssString(this);

--- a/src/css-skew.js
+++ b/src/css-skew.js
@@ -57,7 +57,6 @@
     this.is2D = this.matrix.is2D;
     this.cssText = generateCssString(this);
   }
-
   internal.inherit(CSSSkew, internal.CSSTransformComponent);
 
   scope.CSSSkew = CSSSkew;

--- a/src/css-skew.js
+++ b/src/css-skew.js
@@ -36,17 +36,28 @@
   function CSSSkew(ax, ay) {
     if (arguments.length != 2) {
       throw new TypeError('CSSSkew must have 2 arguments.');
-    } else if (typeof ax != 'number' || typeof ay != 'number') {
-      throw new TypeError('CSSSkew arguments must be of type \'number\'.');
+    // Arguments must both be CSSAngleValues or both be doubles.
+    } else if (!(ay instanceof CSSAngleValue && ax instanceof CSSAngleValue) && !(typeof ay == 'number' && typeof ax == 'number')) {
+      throw new TypeError('CSSSkew arguments must be all numbers or all CSSAngleValues.');
     }
 
-    this.ax = ax;
-    this.ay = ay;
+    if (ax instanceof CSSAngleValue) {
+      this.ax = ax.degrees;
+      this.ay = ay.degrees;
+      this._ax = ax;
+      this._ay = ay;
+    } else {
+      this.ax = ax;
+      this.ay = ay;
+      this._ax = new CSSAngleValue(ax, 'deg');
+      this._ay = new CSSAngleValue(ay, 'deg');
+    }
 
     this.matrix = computeMatrix(this);
     this.is2D = this.matrix.is2D;
     this.cssText = generateCssString(this);
   }
+
   internal.inherit(CSSSkew, internal.CSSTransformComponent);
 
   scope.CSSSkew = CSSSkew;

--- a/test/js/css-skew.js
+++ b/test/js/css-skew.js
@@ -1,31 +1,34 @@
 suite('CSSSkew', function() {
-  test('CSSSkew is a CSSSkew and CSSTransformComponent', function() {
-    var skew = new CSSSkew(1, 2);
-    assert.instanceOf(skew, CSSSkew, 'A new CSSSkew should be an instance of CSSSkew');
-    assert.instanceOf(skew, typedOM.internal.CSSTransformComponent,
-        'A new CSSSkew should be an instance of CSSTransformComponent');
-  });
 
   test('CSSSkew constructor throws exception for invalid types', function() {
-    assert.throws(function() {new CSSSkew()});
-    assert.throws(function() {new CSSSkew({})});
-    assert.throws(function() {new CSSSkew({}, {})});
-    assert.throws(function() {new CSSSkew(1)});
-    assert.throws(function() {new CSSSkew('1', '2')});
-    assert.throws(function() {new CSSSkew(3, null)});
-    assert.throws(function() {new CSSSkew(1, 2, 3)});
+    argCountErr = /^CSSSkew must have 2 arguments\./;
+    assert.throws(function() {new CSSSkew()}, TypeError, argCountErr);
+    assert.throws(function() {new CSSSkew({})}, TypeError, argCountErr);
+    assert.throws(function() {new CSSSkew(1)}, TypeError, argCountErr);
+    assert.throws(function() {new CSSSkew(1, 2, 3)}, TypeError, argCountErr);
+    var argTypeErr = /^CSSSkew arguments must be all numbers or all CSSAngleValues\./;
+    assert.throws(function() {new CSSSkew({}, {})}, TypeError, argTypeErr);
+    assert.throws(function() {new CSSSkew('1', '2')}, TypeError, argTypeErr);
+    assert.throws(function() {new CSSSkew(1, new CSSAngleValue(2, 'deg'))}, TypeError, argTypeErr);
+    assert.throws(function() {new CSSSkew(3, null)}, TypeError, argTypeErr);
   });
 
   test('CSSSkew constructor works correctly', function() {
-    var skew;
-    assert.doesNotThrow(function() {skew = new CSSSkew(30, 180)});
-    assert.strictEqual(skew.cssText, 'skew(30deg, 180deg)');
-    assert.strictEqual(skew.ax, 30);
-    assert.strictEqual(skew.ay, 180);
-    assert.isTrue(skew.is2D);
-
+    var values = [
+      {skew: new CSSSkew(30, 180), cssText: 'skew(30deg, 180deg)'},
+      {skew: new CSSSkew(new CSSAngleValue(30, 'deg'), new CSSAngleValue(180, 'deg')), cssText: 'skew(30deg, 180deg)'},
+      {skew: new CSSSkew(new CSSAngleValue(0.52359878, 'rad'), new CSSAngleValue(3.14159265, 'rad')),
+          cssText: 'skew(30.0000002521989deg, 179.99999979432deg)'}
+    ];
     var expectedMatrix = new DOMMatrixReadonly([1, 0, 0.577350, 1, 0, 0]);
-    typedOM.internal.testing.matricesApproxEqual(skew.matrix, expectedMatrix);
+    for (var i = 0; i < values.length; i++) {
+      assert.strictEqual(values[i].skew.cssText, values[i].cssText);
+      assert.closeTo(values[i].skew.ax, 30, 1e-6);
+      assert.closeTo(values[i].skew.ay, 180, 1e-6);
+      assert.isTrue(values[i].skew.is2D);
+      typedOM.internal.testing.matricesApproxEqual(values[i].skew.matrix, expectedMatrix);
+    }
+
   });
 
   test('Parsing valid strings results in CSSSkew with correct values', function() {


### PR DESCRIPTION
Make CSSSkew work with CSSAngleValue arguments. Slight improvements to tests.

Test case `cssText: 'skew(30.0000002521989deg, 179.99999979432deg)'` will be improved in a future CL which will change cssText to reflect the input angles.
