### PR TITLE
Make cssText for CSSRotation and CSSSkew reflect the input arguments, and related tweaks

### DIFF
--- a/src/css-rotation-parsing.js
+++ b/src/css-rotation-parsing.js
@@ -19,17 +19,25 @@
     if (numbers.length != 4) {
       return null;
     }
-    return [new CSSRotation(numbers[0], numbers[1], numbers[2], new CSSAngleValue(numbers[3], unit)), remaining];
+    var result = [new CSSRotation(numbers[0], numbers[1], numbers[2], new CSSAngleValue(numbers[3], unit)), remaining];
+    result[0]._inputType = '3d';
+    return result;
   }
 
   function rotateXYorZ(type, numbers, unit, remaining) {
     switch (type) {
       case 'x':
-        return [new CSSRotation(1, 0, 0, new CSSAngleValue(numbers[0], unit)), remaining];
+        var result = [new CSSRotation(1, 0, 0, new CSSAngleValue(numbers[0], unit)), remaining];
+        result[0]._inputType = 'x';
+        return result;
       case 'y':
-        return [new CSSRotation(0, 1, 0, new CSSAngleValue(numbers[0], unit)), remaining];
+        var result = [new CSSRotation(0, 1, 0, new CSSAngleValue(numbers[0], unit)), remaining];
+        result[0]._inputType = 'y';
+        return result;
       case 'z':
-        return [new CSSRotation(0, 0, 1, new CSSAngleValue(numbers[0], unit)), remaining];
+        var result = [new CSSRotation(0, 0, 1, new CSSAngleValue(numbers[0], unit)), remaining];
+        result[0]._inputType = 'z';
+        return result;
     }
   }
 
@@ -63,7 +71,9 @@
       return rotateXYorZ(type, numbers, unit, remaining);
     }
 
-    return [new CSSRotation(new CSSAngleValue(numbers[0], unit)), remaining];
+    var result = [new CSSRotation(new CSSAngleValue(numbers[0], unit)), remaining];
+    result._inputType = '2d';
+    return result;
   }
 
   internal.parsing.consumeRotation = consumeRotation;

--- a/src/css-rotation.js
+++ b/src/css-rotation.js
@@ -52,16 +52,21 @@
   };
 
   function generateCssString(cssRotation) {
-    var cssText;
-    if (cssRotation.is2D) {
-      cssText = 'rotate(' + cssRotation._angle.cssText + ')';
-    } else {
-      cssText = 'rotate3d(' + cssRotation.x +
+    switch (cssRotation._inputType) {
+      case '2d':
+        return 'rotate(' + cssRotation._angle.cssText + ')';
+      case '3d':
+        return 'rotate3d(' + cssRotation.x +
           ', ' + cssRotation.y +
           ', ' + cssRotation.z +
           ', ' + cssRotation._angle.cssText + ')';
+      case 'x':
+        return 'rotatex(' + cssRotation._angle.cssText + ')';
+      case 'y':
+        return 'rotatey(' + cssRotation._angle.cssText + ')';
+      case 'z':
+        return 'rotatez(' + cssRotation._angle.cssText + ')';
     }
-    return cssText;
   };
 
 
@@ -85,6 +90,7 @@
     this.x = this.is2D ? null : x;
     this.y = this.is2D ? null : y;
     this.z = this.is2D ? null : z;
+    this._inputType = this.is2D ? '2d' : '3d';
     var angleValue = this.is2D ? x : angle;
     if (angleValue instanceof CSSAngleValue) {
       this.angle = angleValue.degrees;
@@ -95,7 +101,15 @@
     }
 
     this.matrix = computeMatrix(this);
-    this.cssText = generateCssString(this);
+    Object.defineProperty(this, 'cssText', {
+      get: function() {
+        if (!this._cssText) {
+          this._cssText = generateCssString(this);
+        }
+        return this._cssText;
+      },
+      set: function(newCssText) {}
+    });
   }
   internal.inherit(CSSRotation, internal.CSSTransformComponent);
 

--- a/src/css-rotation.js
+++ b/src/css-rotation.js
@@ -54,12 +54,12 @@
   function generateCssString(cssRotation) {
     var cssText;
     if (cssRotation.is2D) {
-      cssText = 'rotate(' + cssRotation.angle + 'deg)';
+      cssText = 'rotate(' + cssRotation._angle.cssText + ')';
     } else {
       cssText = 'rotate3d(' + cssRotation.x +
           ', ' + cssRotation.y +
           ', ' + cssRotation.z +
-          ', ' + cssRotation.angle + 'deg)';
+          ', ' + cssRotation._angle.cssText + ')';
     }
     return cssText;
   };
@@ -86,7 +86,13 @@
     this.y = this.is2D ? null : y;
     this.z = this.is2D ? null : z;
     var angleValue = this.is2D ? x : angle;
-    this.angle = angleValue instanceof CSSAngleValue ? angleValue.degrees : angleValue;
+    if (angleValue instanceof CSSAngleValue) {
+      this.angle = angleValue.degrees;
+      this._angle = angleValue;
+    } else {
+      this.angle = angleValue;
+      this._angle = new CSSAngleValue(angleValue, 'deg');
+    }
 
     this.matrix = computeMatrix(this);
     this.cssText = generateCssString(this);

--- a/src/css-skew-parsing.js
+++ b/src/css-skew-parsing.js
@@ -19,11 +19,16 @@
     if (angles.length != 1) {
       return null;
     }
+    var zeroAngle = new CSSAngleValue(0, 'deg');
     switch (type) {
       case 'x':
-        return [new CSSSkew(angles[0].degrees, 0), remaining];
+        var result = [new CSSSkew(angles[0], zeroAngle), remaining];
+        result[0]._inputType = 'x';
+        return result;
       case 'y':
-        return [new CSSSkew(0, angles[0].degrees), remaining];
+        var result = [new CSSSkew(zeroAngle, angles[0]), remaining];
+        result[0]._inputType = 'y';
+        return result;
     }
   }
 
@@ -46,11 +51,16 @@
     if (type == 'x' || type == 'y') {
       return skewXorY(type, angles, remaining);
     }
+
     if (angles.length == 1) {
-      return [new CSSSkew(angles[0].degrees, 0), remaining];
+      var result = [new CSSSkew(angles[0], new CSSAngleValue(0, 'deg')), remaining];
+      result[0]._inputType = '1';
+      return result;
     }
     if (angles.length == 2) {
-      return [new CSSSkew(angles[0].degrees, angles[1].degrees), remaining];
+      var result = [new CSSSkew(angles[0], angles[1]), remaining];
+      result[0]._inputType = '2';
+      return result;
     }
     return null;
   }

--- a/src/css-skew.js
+++ b/src/css-skew.js
@@ -30,7 +30,16 @@
   };
 
   function generateCssString(cssSkew) {
-    return 'skew(' + cssSkew.ax + 'deg' + ', ' + cssSkew.ay + 'deg' + ')';
+    switch (cssSkew._inputType) {
+      case '1':
+        return 'skew(' + cssSkew._ax.cssText + ')';
+      case '2':
+        return 'skew(' + cssSkew._ax.cssText + ', ' + cssSkew._ay.cssText + ')';
+      case 'x':
+        return 'skewx(' + cssSkew._ax.cssText + ')';
+      case 'y':
+        return 'skewy(' + cssSkew._ay.cssText + ')';
+    }
   };
 
   function CSSSkew(ax, ay) {
@@ -55,8 +64,19 @@
 
     this.matrix = computeMatrix(this);
     this.is2D = this.matrix.is2D;
-    this.cssText = generateCssString(this);
+    this._inputType = '2';
+
+    Object.defineProperty(this, 'cssText', {
+      get: function() {
+        if (!this._cssText) {
+          this._cssText = generateCssString(this);
+        }
+        return this._cssText;
+      },
+      set: function(newCssText) {}
+    });
   }
+
   internal.inherit(CSSSkew, internal.CSSTransformComponent);
 
   scope.CSSSkew = CSSSkew;

--- a/test/js/css-rotation.js
+++ b/test/js/css-rotation.js
@@ -38,11 +38,32 @@ suite('CSSRotation', function() {
     typedOM.internal.testing.matricesApproxEqual(rotation.matrix, expectedMatrix);
   });
 
-  test('CSSRotation constructor works correctly for 4 arguments', function() {
+  test('CSSRotation using CSSAngleValue specified in units other than degrees', function() {
+    var rotation = new CSSRotation(new CSSAngleValue(5, 'rad'));
+    assert.closeTo(rotation.angle, 286.478897, 1e-6);
+  });
+
+  test('CSSRotation constructor works correctly for 4 arguments, number angle', function() {
     var rotation;
     assert.doesNotThrow(function() {rotation = new CSSRotation(1, 0.5, -2, 30)});
     assert.strictEqual(rotation.cssText, 'rotate3d(1, 0.5, -2, 30deg)');
     assert.strictEqual(rotation.angle, 30);
+    assert.strictEqual(rotation.x, 1);
+    assert.strictEqual(rotation.y, 0.5);
+    assert.strictEqual(rotation.z, -2);
+    assert.isFalse(rotation.is2D);
+
+    var expectedMatrix = new DOMMatrixReadonly([0.89154437, -0.42367629, -0.16014688, 0,
+        0.44919526, 0.872405146, 0.19269891, 0, 0.05807100, -0.243736860,
+        0.96810128, 0, 0, 0, 0, 1]);
+    typedOM.internal.testing.matricesApproxEqual(rotation.matrix, expectedMatrix);
+  });
+
+  test('CSSRotation constructor works correctly for 4 arguments, CSSAngleValue angle', function() {
+    var rotation;
+    assert.doesNotThrow(function() {rotation = new CSSRotation(1, 0.5, -2, new CSSAngleValue(0.083333333, 'turn'))});
+    assert.strictEqual(rotation.cssText, 'rotate3d(1, 0.5, -2, 0.083333333turn)');
+    assert.closeTo(rotation.angle, 30, 1e-6);
     assert.strictEqual(rotation.x, 1);
     assert.strictEqual(rotation.y, 0.5);
     assert.strictEqual(rotation.z, -2);
@@ -100,21 +121,16 @@ suite('CSSRotation', function() {
     typedOM.internal.testing.matricesApproxEqual(rotationAngleValue.matrix, rotationNumberValue.matrix);
   });
 
-  test('CSSRotation using CSSAngleValue specified in units other than degrees', function() {
-    var rotation = new CSSRotation(new CSSAngleValue(5, 'rad'));
-    assert.closeTo(rotation.angle, 286.478897, 1e-6);
-  });
-
   test('Parsing valid basic strings results in CSSRotation with correct values', function() {
     var values = [
-      {str: 'rotate(45deg)', deg: 45, remaining: ''},
-      {str: 'rotate(5rad)', deg: 286.478897, remaining: ''},
-      {str: 'rotate(215grad)', deg: 193.5, remaining: ''},
-      {str: 'rotate(0.6turn)', deg: 216, remaining: ''},
-      {str: 'RoTaTe(5dEg)', deg: 5, remaining: ''},
-      {str: 'rOtAtE(4DeG)', deg: 4, remaining: ''},
-      {str: 'rotate(45deg) 123', deg: 45, remaining: '123'},
-      {str: 'rotate(45deg))))', deg: 45, remaining: ')))'},
+      {str: 'rotate(45deg)', deg: 45, cssText: 'rotate(45deg)', remaining: ''},
+      {str: 'rotate(5rad)', deg: 286.478897, cssText: 'rotate(5rad)', remaining: ''},
+      {str: 'rotate(215grad)', deg: 193.5, cssText: 'rotate(215grad)', remaining: ''},
+      {str: 'rotate(0.6turn)', deg: 216, cssText: 'rotate(0.6turn)', remaining: ''},
+      {str: 'RoTaTe(5dEg)', deg: 5, cssText: 'rotate(5deg)', remaining: ''},
+      {str: 'rOtAtE(4DeG)', deg: 4, cssText: 'rotate(4deg)', remaining: ''},
+      {str: 'rotate(45deg) 123', deg: 45, cssText: 'rotate(45deg)', remaining: '123'},
+      {str: 'rotate(45deg))))', deg: 45, cssText: 'rotate(45deg)', remaining: ')))'},
     ];
     for (var i = 0; i < values.length; i++) {
       var parsed = typedOM.internal.parsing.consumeRotation(values[i].str);
@@ -122,25 +138,26 @@ suite('CSSRotation', function() {
       assert.strictEqual(parsed[1], values[i].remaining, values[i].str + ' expected ' + values[i].remaining + ' as trailing characters');
       assert.instanceOf(parsed[0], CSSRotation);
       assert.isTrue(parsed[0].is2D);
-      assert.approximately(parsed[0].angle, values[i].deg, 1e-6);
+      assert.closeTo(parsed[0].angle, values[i].deg, 1e-6);
+      assert.strictEqual(parsed[0].cssText, values[i].cssText);
     }
   });
 
   test('Parsing 3d rotation strings result in CSSRotation with correct values', function() {
     var values = [
-      {str: 'rotate3d(1,2,3,60deg)', x: 1, y: 2, z: 3, deg: 60, remaining: ''},
-      {str: 'rotate3d(1, 2, 3, 60deg)', x: 1, y: 2, z: 3, deg: 60, remaining: ''},
-      {str: 'Rotate3D(1,2,3,60DEG)', x: 1, y: 2, z: 3, deg: 60, remaining: ''},
-      {str: 'rotate3d(1,2,3,60deg)123', x: 1, y: 2, z: 3, deg: 60, remaining: '123'},
-      {str: 'rotatex(10deg)', x: 1, y: 0, z: 0, deg: 10, remaining: ''},
-      {str: 'rotateX(10dEg)', x: 1, y: 0, z: 0, deg: 10, remaining: ''},
-      {str: 'rotatex(10deg) abc', x: 1, y: 0, z: 0, deg: 10, remaining: 'abc'},
-      {str: 'rotatey(20Deg)', x: 0, y: 1, z: 0, deg: 20, remaining: ''},
-      {str: 'rotateY(20deG)', x: 0, y: 1, z: 0, deg: 20, remaining: ''},
-      {str: 'rotatey(20DEG))))', x: 0, y: 1, z: 0, deg: 20, remaining: ')))'},
-      {str: 'rotatez(30dEG)', x: 0, y: 0, z: 1, deg: 30, remaining: ''},
-      {str: 'rotateZ(30DEg)', x: 0, y: 0, z: 1, deg: 30, remaining: ''},
-      {str: 'rotateZ(30deg)abc', x: 0, y: 0, z: 1, deg: 30, remaining: 'abc'},
+      {str: 'rotate3d(1,2,3,60deg)', x: 1, y: 2, z: 3, deg: 60, cssText: 'rotate3d(1, 2, 3, 60deg)', remaining: ''},
+      {str: 'rotate3d(1, 2, 3, 60rad)', x: 1, y: 2, z: 3, deg: 3437.746771, cssText: 'rotate3d(1, 2, 3, 60rad)', remaining: ''},
+      {str: 'Rotate3D(1,2,3,60DEG)', x: 1, y: 2, z: 3, deg: 60, cssText: 'rotate3d(1, 2, 3, 60deg)', remaining: ''},
+      {str: 'rotate3d(1,2,3,60deg)123', x: 1, y: 2, z: 3, deg: 60, cssText: 'rotate3d(1, 2, 3, 60deg)', remaining: '123'},
+      {str: 'rotatex(10TURN)', x: 1, y: 0, z: 0, deg: 3600, cssText: 'rotatex(10turn)', remaining: ''},
+      {str: 'rotateX(10dEg)', x: 1, y: 0, z: 0, deg: 10, cssText: 'rotatex(10deg)', remaining: ''},
+      {str: 'rotatex(10deg) abc', x: 1, y: 0, z: 0, deg: 10, cssText: 'rotatex(10deg)', remaining: 'abc'},
+      {str: 'rotatey(20Deg)', x: 0, y: 1, z: 0, deg: 20, cssText: 'rotatey(20deg)', remaining: ''},
+      {str: 'rotateY(20deG)', x: 0, y: 1, z: 0, deg: 20, cssText: 'rotatey(20deg)', remaining: ''},
+      {str: 'rotatey(20Grad))))', x: 0, y: 1, z: 0, deg: 18, cssText: 'rotatey(20grad)', remaining: ')))'},
+      {str: 'rotatez(30dEG)', x: 0, y: 0, z: 1, deg: 30, cssText: 'rotatez(30deg)', remaining: ''},
+      {str: 'rotateZ(30RAD)', x: 0, y: 0, z: 1, deg: 1718.873385, cssText: 'rotatez(30rad)', remaining: ''},
+      {str: 'rotateZ(30deg)abc', x: 0, y: 0, z: 1, deg: 30, cssText: 'rotatez(30deg)', remaining: 'abc'},
     ]
     for (var i = 0; i < values.length; i++) {
       var parsed = typedOM.internal.parsing.consumeRotation(values[i].str);
@@ -150,7 +167,8 @@ suite('CSSRotation', function() {
       assert.strictEqual(parsed[0].x, values[i].x);
       assert.strictEqual(parsed[0].y, values[i].y);
       assert.strictEqual(parsed[0].z, values[i].z);
-      assert.approximately(parsed[0].angle, values[i].deg, 1e-6);
+      assert.closeTo(parsed[0].angle, values[i].deg, 1e-6);
+      assert.strictEqual(parsed[0].cssText, values[i].cssText);
     }
   });
 

--- a/test/js/css-skew.js
+++ b/test/js/css-skew.js
@@ -17,8 +17,7 @@ suite('CSSSkew', function() {
     var values = [
       {skew: new CSSSkew(30, 180), cssText: 'skew(30deg, 180deg)'},
       {skew: new CSSSkew(new CSSAngleValue(30, 'deg'), new CSSAngleValue(180, 'deg')), cssText: 'skew(30deg, 180deg)'},
-      {skew: new CSSSkew(new CSSAngleValue(0.52359878, 'rad'), new CSSAngleValue(3.14159265, 'rad')),
-          cssText: 'skew(30.0000002521989deg, 179.99999979432deg)'}
+      {skew: new CSSSkew(new CSSAngleValue(0.52359878, 'rad'), new CSSAngleValue(3.14159265, 'rad')), cssText: 'skew(0.52359878rad, 3.14159265rad)'}
     ];
     var expectedMatrix = new DOMMatrixReadonly([1, 0, 0.577350, 1, 0, 0]);
     for (var i = 0; i < values.length; i++) {
@@ -28,27 +27,26 @@ suite('CSSSkew', function() {
       assert.isTrue(values[i].skew.is2D);
       typedOM.internal.testing.matricesApproxEqual(values[i].skew.matrix, expectedMatrix);
     }
-
   });
 
   test('Parsing valid strings results in CSSSkew with correct values', function() {
     var values = [
-      {str: 'skew(45deg)', x: 45, y: 0, remaining: ''}, // skew with 1 arg
-      {str: 'skew(5rad)', x: 286.478897, y: 0, remaining: ''},
-      {str: 'skew(215grad)', x: 193.5, y: 0, remaining: ''},
-      {str: 'skew(0.6turn)', x: 216, y: 0, remaining: ''},
-      {str: 'SkeW(5dEg)', x: 5, y: 0, remaining: ''},
-      {str: 'SKEW(4DeG)', x: 4, y: 0, remaining: ''},
-      {str: 'skew(45deg))))', x: 45, y: 0, remaining: ')))'},
-      {str: 'skew(60deg, -0.2turn)', x: 60, y: -72, remaining: ''}, // skew with 2 args
-      {str: 'SkEW(0.2TURN, 1Rad)', x: 72, y: 57.295780, remaining: ''},
-      {str: 'skew(20deg, 1rad) 123', x: 20, y: 57.295780, remaining: '123'},
-      {str: 'skewx(10deg)', x: 10, y: 0, remaining: ''}, // skewx
-      {str: 'SkewX(1TuRn)', x: 360, y: 0, remaining: ''},
-      {str: 'skewx(100grad) abc', x: 90, y: 0, remaining: 'abc'},
-      {str: 'skewy(0.45turn)', x: 0, y: 162, remaining: ''}, // skewy
-      {str: 'SkEwY(2.1RAD)', x: 0, y: 120.321137, remaining: ''},
-      {str: 'skewy(20DEG))))', x: 0, y: 20, remaining: ')))'},
+      {str: 'skew(45deg)', x: 45, y: 0, cssText: 'skew(45deg)', remaining: ''}, // skew with 1 arg
+      {str: 'skew(5rad)', x: 286.478897, y: 0, cssText: 'skew(5rad)', remaining: ''},
+      {str: 'skew(215grad)', x: 193.5, y: 0, cssText: 'skew(215grad)', remaining: ''},
+      {str: 'skew(0.6turn)', x: 216, y: 0, cssText: 'skew(0.6turn)', remaining: ''},
+      {str: 'SkeW(5dEg)', x: 5, y: 0, cssText: 'skew(5deg)', remaining: ''},
+      {str: 'SKEW(4DeG)', x: 4, y: 0, cssText: 'skew(4deg)', remaining: ''},
+      {str: 'skew(45deg))))', x: 45, y: 0, cssText: 'skew(45deg)', remaining: ')))'},
+      {str: 'skew(60deg, -0.2turn)', x: 60, y: -72, cssText: 'skew(60deg, -0.2turn)', remaining: ''}, // skew with 2 args
+      {str: 'SkEW(0.2TURN, 1Rad)', x: 72, y: 57.295780, cssText: 'skew(0.2turn, 1rad)', remaining: ''},
+      {str: 'skew(20deg, 1rad) 123', x: 20, y: 57.295780, cssText: 'skew(20deg, 1rad)', remaining: '123'},
+      {str: 'skewx(10deg)', x: 10, y: 0, cssText: 'skewx(10deg)', remaining: ''}, // skewx
+      {str: 'SkewX(1TuRn)', x: 360, y: 0, cssText: 'skewx(1turn)', remaining: ''},
+      {str: 'skewx(100grad) abc', x: 90, y: 0, cssText: 'skewx(100grad)', remaining: 'abc'},
+      {str: 'skewy(0.45turn)', x: 0, y: 162, cssText: 'skewy(0.45turn)', remaining: ''}, // skewy
+      {str: 'SkEwY(2.1RAD)', x: 0, y: 120.321137, cssText: 'skewy(2.1rad)', remaining: ''},
+      {str: 'skewy(20DEG))))', x: 0, y: 20, cssText: 'skewy(20deg)', remaining: ')))'},
     ];
     for (var i = 0; i < values.length; i++) {
       var parsed = typedOM.internal.parsing.consumeSkew(values[i].str);
@@ -56,6 +54,7 @@ suite('CSSSkew', function() {
       assert.strictEqual(parsed[1], values[i].remaining, values[i].str + ' expected ' + values[i].remaining + ' as trailing characters');
       assert.instanceOf(parsed[0], CSSSkew);
       assert.isTrue(parsed[0].is2D); // Skew matrices should always be 2D
+      assert.strictEqual(parsed[0].cssText, values[i].cssText);
       assert.approximately(parsed[0].ax, values[i].x, 1e-6);
       assert.approximately(parsed[0].ay, values[i].y, 1e-6);
     }


### PR DESCRIPTION
Make cssText for CSSRotation and CSSSkew reflect the input arguments (or input string, in the case of the parser). Also make the getter lazy, and add tests for cssText.

See the (spec section)[https://drafts.css-houdini.org/css-typed-om-1/#csstransformvalue] on CSSTransformComponent cssText.
