### PR TITLE
Make including typed om work when running locally and when using http

### DIFF
--- a/typed-om.js
+++ b/typed-om.js
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 var TYPED_OM_TESTING = false;
-var typedOMIncludePath = typedOMIncludePath || '/typed-om';
+var typedOMIncludePath = typedOMIncludePath || 'typed-om';
 var loadScript = function(sourceFile) {
   return new Promise(function(resolve, reject) {
     var s = document.createElement('script');


### PR DESCRIPTION
Fixes https://github.com/css-typed-om/typed-om/issues/78

I tested this using the following directory structure and code:

```
outerdir/typed-om
outerdir/test.html
```

``` html
<script src='typed-om/typed-om.js'></script>
<script>
document.onreadystatechange = function () {
    if (document.readyState == "complete") {
      var matrix = new window.DOMMatrixReadonly([5, 5, 5, 5, 5, 5]);
      console.log(matrix);
    }
};
</script>
```

Then I opened outerdir/test.html using file:///path/to/outerdir/test.html, and also by running a python http server in outerdir:

``` python
python -m SimpleHTTPServer 6060
```

then opening localhost:6060/test.html.
