### PR TITLE
Wire up consumers & make all consumers return null on failure

### DIFF
--- a/src/css-style-value.js
+++ b/src/css-style-value.js
@@ -25,49 +25,15 @@
     if (typeof cssText != 'string') {
       throw new TypeError('Must parse a string');
     }
-    if (!internal.propertyDictionary().isSupportedProperty(property)) {
-      // TODO: How do custom properties play into this?
-      throw new TypeError('Can\'t parse an unsupported property.');
+
+    var consumed = internal.parsing.consumeStyleValueOrStyleValueList(property, cssText);
+    if (consumed && !consumed[1]) {
+      // Format is [ parsedThing, remainingString ], in this case
+      // [ styleValueOrStyleValueList, remainingString ]
+      // But there shouldn't be trailing characters.
+      return consumed[0];
     }
-
-    // Currently only supports sequences separated by ', '
-    var valueArray = cssText.toLowerCase().split(', ');
-    var styleValueArray = [];
-    var supportedStyleValues =
-        internal.propertyDictionary().getValidStyleValuesArray(property);
-
-    var styleValueObject = null;
-    var successfulParse = false;
-    for (var i = 0; i < valueArray.length; i++) {
-      var cssTextStyleValue = valueArray[i];
-      cssTextStyleValue = cssTextStyleValue.trim();
-      if (internal.propertyDictionary().isValidKeyword(property, cssTextStyleValue)) {
-        styleValueArray[i] = new CSSKeywordValue(cssTextStyleValue);
-        continue;
-      }
-
-      styleValueObject = null;
-      successfulParse = false;
-      for (var j = 0; j < supportedStyleValues.length; j++) {
-        try {
-          styleValueObject = supportedStyleValues[j].from(cssTextStyleValue);
-        } catch (e) {
-          // Ensures method does not terminate if a CSSStyleValue fom method throws an error
-          continue;
-        }
-        if (styleValueObject != null) {
-          styleValueArray[i] = styleValueObject;
-          successfulParse = true;
-          break;
-        }
-      }
-
-      if (!successfulParse) {
-        throw new TypeError(property +
-          ' has an unsupported CSSStyleValue type or Sequence value separator');
-      }
-    }
-    return styleValueArray;
+    return null;
   };
 
   scope.CSSStyleValue = CSSStyleValue;

--- a/src/parsing/css-length-value-parsing.js
+++ b/src/parsing/css-length-value-parsing.js
@@ -17,7 +17,7 @@
   var unitRegExpStr = 'px|%|em|ex|ch|rem|vw|vh|vmin|vmax|cm|mm|in|pt|pc';
 
   function isCalc(string) {
-    return /^calc/.test(string); 
+    return /^calc/i.test(string);
   }
 
   // Returns a calc dictionary.
@@ -114,7 +114,7 @@
   }
 
   function consumeCalcLength(str) {
-    var consumedCalcToken = internal.parsing.consumeToken(/^calc/, str);
+    var consumedCalcToken = internal.parsing.consumeToken(/^calc/i, str);
     if (!consumedCalcToken) {
       return;
     }

--- a/src/parsing/css-length-value-parsing.js
+++ b/src/parsing/css-length-value-parsing.js
@@ -69,7 +69,7 @@
     // If we don't end up only with a number tag after reducing, the
     // expression is invalid.
     if (typeCheck != 'D') {
-      return;
+      return null;
     }
 
     for (var unit in matchedUnits) {
@@ -77,7 +77,7 @@
       var result = eval(string.replace(new RegExp('U' + unit, 'g'), '').replace(
             new RegExp(taggedUnitRegExp, 'g'), '*0'));
       if (!isFinite(result)) {
-        return;
+        return null;
       }
       matchedUnits[unit] = result;
     }

--- a/src/parsing/css-length-value-parsing.js
+++ b/src/parsing/css-length-value-parsing.js
@@ -95,7 +95,7 @@
   function consumeSimpleLength(str) {
     var consumedNumber = internal.parsing.consumeNumber(str);
     if (!consumedNumber) {
-      return;
+      return null;
     }
     var unitRegExp = new RegExp('^' + unitRegExpStr, 'gi');
     var consumedUnit = internal.parsing.consumeToken(unitRegExp, consumedNumber[1]);
@@ -103,7 +103,7 @@
       if (consumedNumber[0] == 0) {
         return [new CSSSimpleLength(0, 'px'), consumedNumber[1]];
       }
-      return;
+      return null;
     }
     if (consumedUnit[0] == '%') {
       // Percent is a special case - We require 'percent' instead
@@ -116,14 +116,14 @@
   function consumeCalcLength(str) {
     var consumedCalcToken = internal.parsing.consumeToken(/^calc/i, str);
     if (!consumedCalcToken) {
-      return;
+      return null;
     }
 
     // Consume until balanced closing parens
     var result = internal.parsing.consumeParenthesised(
         parseDimension, consumedCalcToken[1]);
     if (!result) {
-      return;
+      return null;
     }
 
     return [new CSSCalcLength(result[0]), result[1]];

--- a/src/parsing/css-position-value-parsing.js
+++ b/src/parsing/css-position-value-parsing.js
@@ -20,7 +20,7 @@
         null, // separator not required due to use of consumeTrimmed.
         str);
     if (!params || params[0].length != 2) {
-      return;
+      return null;
     }
     var lengths = params[0];
     return [new CSSPositionValue(lengths[0], lengths[1]), params[1]];

--- a/src/parsing/css-rotation-parsing.js
+++ b/src/parsing/css-rotation-parsing.js
@@ -39,6 +39,7 @@
         result[0]._inputType = 'z';
         return result;
     }
+    return null;
   }
 
   function consumeRotation(string) {

--- a/src/parsing/css-scale-parsing.js
+++ b/src/parsing/css-scale-parsing.js
@@ -34,6 +34,7 @@
       case 'z':
         return [new CSSScale(1, 1, numbers[0]), remaining];
     }
+    return null;
   }
 
   function consumeScale(string) {

--- a/src/parsing/css-skew-parsing.js
+++ b/src/parsing/css-skew-parsing.js
@@ -30,6 +30,7 @@
         result[0]._inputType = 'y';
         return result;
     }
+    return null;
   }
 
   function consumeSkew(string) {

--- a/src/parsing/css-style-value-parsing.js
+++ b/src/parsing/css-style-value-parsing.js
@@ -19,13 +19,6 @@
   parsers['CSSLengthValue'] = internal.parsing.consumeLengthValue;
   parsers['CSSTransformValue'] = internal.parsing.consumeTransformValue;
 
-  function maybeConsume(consumer, string) {
-    if (!consumer) {
-      return null;
-    }
-    return consumer(string);
-  }
-
   function consumeKeyword(property, string) {
     var consumed = internal.parsing.consumeToken(/^[a-z_]+[a-z0-9_-]*/i, string);
     if (!consumed) {
@@ -50,8 +43,8 @@
 
     var supportedStyleValues = internal.propertyDictionary().supportedStyleValues(property);
     for (var i = 0; i < supportedStyleValues.length; i++) {
-      var parsed = maybeConsume(parsers[supportedStyleValues[i].name], string);
-      if (parsed) {
+      var parsed, consumer = parsers[supportedStyleValues[i].name];
+      if (consumer && (parsed = consumer(string))) {
         return parsed;
       }
     }

--- a/src/parsing/css-style-value-parsing.js
+++ b/src/parsing/css-style-value-parsing.js
@@ -1,0 +1,74 @@
+// Copyright 2016 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//     You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//     See the License for the specific language governing permissions and
+// limitations under the License.
+
+(function(internal) {
+
+  var parsers = {};
+  parsers[CSSNumberValue] = internal.parsing.consumeNumber;
+  parsers[CSSLengthValue] = internal.parsing.consumeLength;
+  parsers[CSSTransformValue] = internal.parsing.consumeTransform;
+
+  function consume(consumer, string) {
+    if (!consumer) {
+      return null;
+    }
+    return consumer(string);
+  }
+
+  function consumeKeyword(property, string) {
+    var consumed = internal.parsing.consumeToken(/^[a-z_]+[a-z0-9_-]*/i, string);
+    if (!consumed) {
+      return null;
+    }
+    if (!internal.propertyDictionary().isValidKeyword(property, consumed[0])) {
+      return null;
+    }
+    return [new CSSKeywordValue(consumed[0]), consumed[1]];
+  }
+
+  function consumeStyleValue(property, string) {
+    if (!internal.propertyDictionary().isSupportedProperty(property)) {
+      // TODO: How do custom properties play into this?
+      return null;
+    }
+
+    var consumedKeyword = consumeKeyword(property, string);
+    if (consumedKeyword) {
+      return consumedKeyword;
+    }
+
+    var supportedStyleValues = internal.propertyDictionary().supportedStyleValues(property);
+    for (var i = 0; i < supportedStyleValues.length; i++) {
+      var parsed = consume(parsers[supportedStyleValues[i]], string);
+      if (parsed) {
+        return parsed;
+      }
+    }
+
+    return null;
+  }
+
+  function consumeStyleValueOrStyleValueList(property, string) {
+    var propertyDictionary = internal.propertyDictionary();
+    if (propertyDictionary.isListValuedProperty(property)) {
+      var separator = propertyDictionary.listValueSeparator(property);
+      return internal.parsing.consumeRepeated(consumeStyleValue.bind(null, property), separator, string);
+    } else {
+      return consumeStyleValue(property, string);
+    }
+  }
+
+  internal.parsing.consumeStyleValueOrStyleValueList = consumeStyleValueOrStyleValueList;
+
+})(typedOM.internal);

--- a/src/parsing/css-style-value-parsing.js
+++ b/src/parsing/css-style-value-parsing.js
@@ -15,11 +15,11 @@
 (function(internal) {
 
   var parsers = {};
-  parsers[CSSNumberValue] = internal.parsing.consumeNumber;
-  parsers[CSSLengthValue] = internal.parsing.consumeLength;
-  parsers[CSSTransformValue] = internal.parsing.consumeTransform;
+  parsers['CSSNumberValue'] = internal.parsing.consumeNumberValue;
+  parsers['CSSLengthValue'] = internal.parsing.consumeLengthValue;
+  parsers['CSSTransformValue'] = internal.parsing.consumeTransformValue;
 
-  function consume(consumer, string) {
+  function maybeConsume(consumer, string) {
     if (!consumer) {
       return null;
     }
@@ -50,12 +50,11 @@
 
     var supportedStyleValues = internal.propertyDictionary().supportedStyleValues(property);
     for (var i = 0; i < supportedStyleValues.length; i++) {
-      var parsed = consume(parsers[supportedStyleValues[i]], string);
+      var parsed = maybeConsume(parsers[supportedStyleValues[i].name], string);
       if (parsed) {
         return parsed;
       }
     }
-
     return null;
   }
 

--- a/src/parsing/css-style-value-parsing.js
+++ b/src/parsing/css-style-value-parsing.js
@@ -43,8 +43,12 @@
 
     var supportedStyleValues = internal.propertyDictionary().supportedStyleValues(property);
     for (var i = 0; i < supportedStyleValues.length; i++) {
-      var parsed, consumer = parsers[supportedStyleValues[i].name];
-      if (consumer && (parsed = consumer(string))) {
+      var consumer = parsers[supportedStyleValues[i].name];
+      if (!consumer) {
+        continue;
+      }
+      var parsed = consumer(string);
+      if (parsed) {
         return parsed;
       }
     }

--- a/src/parsing/css-transform-component-parsing.js
+++ b/src/parsing/css-transform-component-parsing.js
@@ -20,8 +20,9 @@
     'rotate': internal.parsing.consumeRotation,
     'scale': internal.parsing.consumeScale,
     'skew': internal.parsing.consumeSkew,
-    'translate': internal.parsing.consumeTranslate,
+    'translate': internal.parsing.consumeTranslation,
   };
+
 
   function consumeTransformComponent(string) {
     for (var fn in transformFunctions) {

--- a/src/parsing/css-translation-parsing.js
+++ b/src/parsing/css-translation-parsing.js
@@ -35,6 +35,7 @@
       case 'z':
         return [new CSSTranslation(zeroLength, zeroLength, coords[0]), remaining];
     }
+    return null;
   }
 
   function consumeTranslation(string) {

--- a/src/parsing/parsing.js
+++ b/src/parsing/parsing.js
@@ -23,7 +23,7 @@
     return numberValueRegex.test(cssText);
   }
 
-  // The consumeX functions all return pairs of    
+  // The consumeX functions all return pairs of
   // [consumed, remainingString] (or undefined, if nothing was consumed).
 
   function ignore(consumerFn) {
@@ -49,6 +49,7 @@
       match[0] = regex.ignoreCase ? match[0].toLowerCase() : match[0];
       return [match[0], string.substr(match[0].length)];
     }
+    return null;
   }
 
   function consumeNumber(string) {
@@ -65,8 +66,8 @@
     if (result) {
       // Remove whitespace from the start of the remainder string too.
       result[1] = result[1].replace(/^\s*/, '');
-      return result;
     }
+    return result;
   }
 
   function consumeRepeated(consumer, separator, string, opt_max) {
@@ -101,7 +102,7 @@
     for (var i = 0; i < list.length; i++) {
       var result = consumeTrimmed(list[i], input);
       if (!result)
-        return;
+        return null;
       if (result[0] !== undefined)
         output.push(result[0]);
       input = result[1];
@@ -109,6 +110,7 @@
     if (output.length) {
       return [output, input];
     }
+    return null;
   }
 
   // Consumes a token or expression with balanced parentheses
@@ -128,7 +130,10 @@
       }
     }
     var parsed = parser(string.substr(0, n));
-    return parsed == undefined ? undefined : [parsed, string.substr(n)];
+    if (parsed) {
+      return [parsed, string.substr(n)];
+    }
+    return null;
   }
 
   internal.parsing.NUMBER_REGEX_STR = numberValueRegexStr;

--- a/src/property-dictionary.js
+++ b/src/property-dictionary.js
@@ -50,14 +50,14 @@
     return (this._listSeparator.hasOwnProperty(property));
   };
 
-  PropertyDictionary.prototype.getValidStyleValuesArray = function(property) {
+  PropertyDictionary.prototype.supportedStyleValues = function(property) {
     if (!this.isSupportedProperty(property)) {
       throw new TypeError(property + ' is not a supported CSS property');
     }
     return this._validProperties[property];
   };
 
-  PropertyDictionary.prototype.getListValueSeparator = function(property) {
+  PropertyDictionary.prototype.listValueSeparator = function(property) {
     if (this.isListValuedProperty(property)) {
       return this._listSeparator[property];
     }
@@ -78,8 +78,7 @@
     return (lengthValue.type == 'percent');
   };
 
-  PropertyDictionary.prototype.
-      isValidKeyword = function(property, styleValueString) {
+  PropertyDictionary.prototype.isValidKeyword = function(property, styleValueString) {
     return this._validKeywords[property].indexOf(styleValueString) > -1;
   };
 

--- a/src/style-property-map.js
+++ b/src/style-property-map.js
@@ -61,7 +61,7 @@
     }
 
     var cssAppendString = this._styleObject[property];
-    var valueSeparator = cssPropertyDictionary.getListValueSeparator(property);
+    var valueSeparator = cssPropertyDictionary.listValueSeparator(property);
     for (var i = 0; i < values.length; i++) {
       if (!cssPropertyDictionary.isValidInput(property, values[i])) {
         cssPropertyDictionary.throwInvalidInputError(property, values[i]);

--- a/target-config.js
+++ b/target-config.js
@@ -46,6 +46,10 @@
       'src/css-simple-length.js',
       'src/css-calc-length.js',
       'src/css-position-value.js', // Depends on LengthValues.
+      'src/css-position-value-parsing.js',
+      // Depends on both transform component subclasses and length parsing.
+      'src/css-transform-component-parsing.js',
+      'src/parsing/css-style-value-parsing.js',
       // Other stuff.
       'src/dom-matrix-readonly.js',
       'src/style-property-map-readonly.js',

--- a/target-config.js
+++ b/target-config.js
@@ -20,7 +20,7 @@
 
   // These should be alphabetical order as much as possible.
   var typedOMSrc = [
-      // Utility functions.
+      // Utility functions
       'src/util.js',
       // CSSTransformComponent and subclasses
       'src/css-transform-component.js',
@@ -45,8 +45,9 @@
       'src/css-length-value.js',
       'src/css-simple-length.js',
       'src/css-calc-length.js',
-      'src/css-position-value.js', // Depends on LengthValues.
-      // Other stuff.
+      // Depends on LengthValues
+      'src/css-position-value.js',
+      // Other stuff
       'src/dom-matrix-readonly.js',
       'src/style-property-map-readonly.js',
       'src/style-property-map.js',
@@ -66,7 +67,7 @@
       'src/parsing/css-length-value-parsing.js',
       'src/parsing/css-position-value-parsing.js',
       'src/parsing/css-transform-component-parsing.js',
-      // Depends on both transform component subclasses and length parsing.
+      // Depends on both transform component subclasses and length parsing
       'src/parsing/css-style-value-parsing.js',
   ];
 

--- a/target-config.js
+++ b/target-config.js
@@ -46,10 +46,6 @@
       'src/css-simple-length.js',
       'src/css-calc-length.js',
       'src/css-position-value.js', // Depends on LengthValues.
-      'src/css-position-value-parsing.js',
-      // Depends on both transform component subclasses and length parsing.
-      'src/css-transform-component-parsing.js',
-      'src/parsing/css-style-value-parsing.js',
       // Other stuff.
       'src/dom-matrix-readonly.js',
       'src/style-property-map-readonly.js',
@@ -70,6 +66,8 @@
       'src/parsing/css-length-value-parsing.js',
       'src/parsing/css-position-value-parsing.js',
       'src/parsing/css-transform-component-parsing.js',
+      // Depends on both transform component subclasses and length parsing.
+      'src/parsing/css-style-value-parsing.js',
   ];
 
   var typedOMTest = [

--- a/test/js/css-position-value.js
+++ b/test/js/css-position-value.js
@@ -34,11 +34,11 @@ suite('CSSPositionValue', function() {
     assert.strictEqual(result[0].cssText, input);
   });
 
-  test('Invalid input to parsing returns undefined (and does not throw)', function() {
-    assert.isUndefined(typedOM.internal.parsing.parsePositionValue(''));
-    assert.isUndefined(typedOM.internal.parsing.parsePositionValue('bananas'));
-    assert.isUndefined(typedOM.internal.parsing.parsePositionValue('5px'));
-    assert.isUndefined(typedOM.internal.parsing.parsePositionValue('6px 3'));
-    assert.isUndefined(typedOM.internal.parsing.parsePositionValue('calc(3px - 3em 6px'));
+  test('Invalid input to parsing returns null (and does not throw)', function() {
+    assert.isNull(typedOM.internal.parsing.parsePositionValue(''));
+    assert.isNull(typedOM.internal.parsing.parsePositionValue('bananas'));
+    assert.isNull(typedOM.internal.parsing.parsePositionValue('5px'));
+    assert.isNull(typedOM.internal.parsing.parsePositionValue('6px 3'));
+    assert.isNull(typedOM.internal.parsing.parsePositionValue('calc(3px - 3em 6px'));
   });
 });

--- a/test/js/css-style-value.js
+++ b/test/js/css-style-value.js
@@ -1,30 +1,47 @@
 suite('CSSStyleValue', function() {
-  test('parse successfully creates a CSSKeywordValue object if the cssText is a valid keyword for a property', function() {
+  test('parse works for keywords', function() {
     var keywordValue  = CSSStyleValue.parse('height', 'auto');
-
     assert.strictEqual(keywordValue.cssText, 'auto');
   });
 
-  test('parse successfully creates a CSSLengthValue object if the cssText is a valid and the property supports lengthValues', function() {
+  test('parse works for lengths', function() {
     var value = CSSStyleValue.parse('height', 'calc(10px + 3em)');
-
     assert.strictEqual(value.cssText, 'calc(10px + 3em)');
+    assert.strictEqual(value.px, 10);
+    assert.strictEqual(value.em, 3);
+
+    value = CSSStyleValue.parse('height', '11px');
+    assert.strictEqual(value.cssText, '11px');
+    assert.strictEqual(value.value, 11);
+    assert.strictEqual(value.type, 'px');
+  });
+
+  test('parse works for numbers', function() {
+    var value = CSSStyleValue.parse('opacity', '0.3');
+    assert.strictEqual(value.cssText, '0.3');
+    assert.strictEqual(value.value, 0.3);
+  });
+
+  test('parse works for transforms', function() {
+    var value = CSSStyleValue.parse('transform', 'translate(10px)');
+    console.log(value);
+    assert.strictEqual(value.cssText, 'translate(10px, 0px)');
+    assert.instanceOf(value.transformComponents[0], CSSTranslation);
+    assert.strictEqual(value.transformComponents[0].x.value, 10);
+    assert.strictEqual(value.transformComponents[0].x.type, 'px');
+    assert.strictEqual(value.transformComponents[0].y.value, 0);
+    assert.strictEqual(value.transformComponents[0].y.type, 'px');
+    // TODO: Renee: Really? Null?
+    assert.isNull(value.transformComponents[0].z);
+    // TODO: Renee: Add skewx(10rad), rotate(1rad), rotate3d(1, 1, 1, 1rad) and more.
   });
 
   test('parse should be case insensitive', function() {
     var value = CSSStyleValue.parse('height', 'CaLc(10px + 3em)');
-
     assert.strictEqual(value.cssText, 'calc(10px + 3em)');
   });
 
-  // Skipping until parse is hooked up through methods other than .from
-  test.skip('parse successfully creates an array of CSSStyleValue objects if the cssText is a valid list of values ' +
-    'for a property', function() {
-    var keywordValueArray = CSSStyleValue.parse('animation-iteration-count', 'infinite, 4, 5, 7, 9');
-
-    assert.deepEqual(keywordValueArray, [new CSSKeywordValue('infinite'), new CSSNumberValue(4), new CSSNumberValue(5), new CSSNumberValue(7), new CSSNumberValue(9)]);
-  });
-
+  //TODO: Renee: Make these check the error string.
   test('parse throws an error if either the property or the cssText is not a string', function() {
     assert.throws(function() {CSSStyleValue.parse(4, 'auto')}, TypeError, 'Property name must be a string');
     assert.throws(function() {CSSStyleValue.parse('height', 5)}, TypeError, 'Must parse a string');
@@ -38,6 +55,7 @@ suite('CSSStyleValue', function() {
     assert.isNull(CSSStyleValue.parse('height', '10'));
   });
 
+  //TODO: Renee: Make these check the error string.
   test('instantiating CSSStyleValue throws', function() {
     assert.throws(function() {new CSSStyleValue('10px')}, TypeError, 'CSSStyleValue cannot be instantiated.');
   });
@@ -47,5 +65,12 @@ suite('CSSStyleValue', function() {
     assert.doesNotThrow(function() { internalStyleValue = new typedOM.internal.CSSStyleValue('foo'); });
     assert.strictEqual(internalStyleValue.cssText, 'foo');
     assert.strictEqual(internalStyleValue.constructor, CSSStyleValue);
+  });
+
+  // Skipping until parse is hooked up through methods other than .from
+  test.skip('parse successfully creates an array of CSSStyleValue objects if the cssText is a valid list of values ' +
+    'for a property', function() {
+    var keywordValueArray = CSSStyleValue.parse('animation-iteration-count', 'infinite, 4, 5, 7, 9');
+    assert.deepEqual(keywordValueArray, [new CSSKeywordValue('infinite'), new CSSNumberValue(4), new CSSNumberValue(5), new CSSNumberValue(7), new CSSNumberValue(9)]);
   });
 });

--- a/test/js/css-style-value.js
+++ b/test/js/css-style-value.js
@@ -30,12 +30,12 @@ suite('CSSStyleValue', function() {
     assert.throws(function() {CSSStyleValue.parse('height', 5)}, TypeError, 'Must parse a string');
   });
 
-  test('parse throws an error if an unsupported property is entered', function() {
-    assert.throws(function() {CSSStyleValue.parse('lemons', '10px')}, TypeError, 'Can\'t parse an unsupported property.');
+  test('parse returns null if an unsupported property is entered', function() {
+    assert.isNull(CSSStyleValue.parse('lemons', '10px'));
   });
 
-  test('parse throws an error if a cssText representing a CSSStyleValue type unsupported by a property is entered', function() {
-    assert.throws(function() {CSSStyleValue.parse('height', '10')}, TypeError, 'height has an unsupported CSSStyleValue type or Sequence value separator');
+  test('parse returns null if a cssText representing a CSSStyleValue type unsupported by a property is entered', function() {
+    assert.isNull(CSSStyleValue.parse('height', '10'));
   });
 
   test('instantiating CSSStyleValue throws', function() {

--- a/test/js/css-style-value.js
+++ b/test/js/css-style-value.js
@@ -22,18 +22,107 @@ suite('CSSStyleValue', function() {
     assert.strictEqual(value.value, 0.3);
   });
 
-  test('parse works for transforms', function() {
+  test('parse works for transform(translate)', function() {
     var value = CSSStyleValue.parse('transform', 'translate(10px)');
-    console.log(value);
+    // TODO: Change cssText for CSSTranslation so that it reflects parsed string.
     assert.strictEqual(value.cssText, 'translate(10px, 0px)');
     assert.instanceOf(value.transformComponents[0], CSSTranslation);
     assert.strictEqual(value.transformComponents[0].x.value, 10);
     assert.strictEqual(value.transformComponents[0].x.type, 'px');
     assert.strictEqual(value.transformComponents[0].y.value, 0);
     assert.strictEqual(value.transformComponents[0].y.type, 'px');
-    // TODO: Renee: Really? Null?
+    // TODO: Change this to something sensible. Udate spec?
     assert.isNull(value.transformComponents[0].z);
-    // TODO: Renee: Add skewx(10rad), rotate(1rad), rotate3d(1, 1, 1, 1rad) and more.
+
+    value = CSSStyleValue.parse('transform', 'translatez(1px)');
+    assert.strictEqual(value.cssText, 'translate3d(0px, 0px, 1px)');
+    assert.instanceOf(value.transformComponents[0], CSSTranslation);
+    assert.strictEqual(value.transformComponents[0].x.value, 0);
+    assert.strictEqual(value.transformComponents[0].x.type, 'px');
+    assert.strictEqual(value.transformComponents[0].y.value, 0);
+    assert.strictEqual(value.transformComponents[0].y.type, 'px');
+    assert.strictEqual(value.transformComponents[0].z.value, 1);
+    assert.strictEqual(value.transformComponents[0].y.type, 'px');
+  });
+
+  test('parse works for transform(skew)', function() {
+    var value = CSSStyleValue.parse('transform', 'skewx(10rad)');
+    assert.strictEqual(value.cssText, 'skewx(10rad)');
+    assert.instanceOf(value.transformComponents[0], CSSSkew);
+    assert.strictEqual(value.transformComponents[0].ax.radians, 10);
+    assert.strictEqual(value.transformComponents[0].ay.degrees, 0);
+
+    value = CSSStyleValue.parse('transform', 'skew(1rad, 30deg)');
+    assert.strictEqual(value.cssText, 'skew(1rad, 30deg)');
+    assert.instanceOf(value.transformComponents[0], CSSSkew);
+    assert.strictEqual(value.transformComponents[0].ax.radians, 1);
+    assert.strictEqual(value.transformComponents[0].ay.degrees, 30);
+
+    value = CSSStyleValue.parse('transform', 'skew(0.5turn)');
+    assert.strictEqual(value.cssText, 'skew(0.5turn)');
+    assert.instanceOf(value.transformComponents[0], CSSSkew);
+    assert.strictEqual(value.transformComponents[0].ax.degrees, 180);
+    assert.strictEqual(value.transformComponents[0].ay.degrees, 0);
+  });
+
+  test('parse works for transform(rotate)', function() {
+    var value = CSSStyleValue.parse('transform', 'rotate(1rad)');
+    assert.strictEqual(value.cssText, 'rotate(1rad)');
+    assert.instanceOf(value.transformComponents[0], CSSRotation);
+    assert.strictEqual(value.transformComponents[0].angle.radians, 1);
+
+    value = CSSStyleValue.parse('transform', 'rotate3d(1, 1, 1, 15deg)');
+    assert.strictEqual(value.cssText, 'rotate3d(1, 1, 1, 15deg)');
+    assert.instanceOf(value.transformComponents[0], CSSRotation);
+    assert.strictEqual(value.transformComponents[0].x, 1);
+    assert.strictEqual(value.transformComponents[0].y, 1);
+    assert.strictEqual(value.transformComponents[0].z, 1);
+    assert.strictEqual(value.transformComponents[0].angle.degrees, 15);
+  });
+
+  test('parse works for transform(scale)', function() {
+    var value = CSSStyleValue.parse('transform', 'scale(2)');
+    // TODO: Change cssText for CSSScale so that it reflects parsed string.
+    assert.strictEqual(value.cssText, 'scale(2, 2)');
+    assert.instanceOf(value.transformComponents[0], CSSScale);
+    assert.strictEqual(value.transformComponents[0].x, 2);
+    assert.strictEqual(value.transformComponents[0].y, 2);
+    // TODO: Change this to something sensible. Udate spec?
+    assert.isNull(value.transformComponents[0].z);
+
+    value = CSSStyleValue.parse('transform', 'scaley(2)');
+    assert.strictEqual(value.cssText, 'scale(1, 2)');
+    assert.instanceOf(value.transformComponents[0], CSSScale);
+    assert.strictEqual(value.transformComponents[0].x, 1);
+    assert.strictEqual(value.transformComponents[0].y, 2);
+    assert.isNull(value.transformComponents[0].z);
+
+    value = CSSStyleValue.parse('transform', 'scalez(2)');
+    assert.strictEqual(value.cssText, 'scale3d(1, 1, 2)');
+    assert.instanceOf(value.transformComponents[0], CSSScale);
+    assert.strictEqual(value.transformComponents[0].x, 1);
+    assert.strictEqual(value.transformComponents[0].y, 1);
+    assert.strictEqual(value.transformComponents[0].z, 2);
+  });
+
+  test('parse works for transform(matrix)', function() {
+    var value = CSSStyleValue.parse('transform', 'matrix(2, 0, 2, 2, 0, 0)');
+    assert.strictEqual(value.cssText, 'matrix(2, 0, 2, 2, 0, 0)');
+    assert.instanceOf(value.transformComponents[0], CSSMatrix);
+    typedOM.internal.testing.matricesApproxEqual(value.transformComponents[0].matrix, new DOMMatrixReadonly([2, 0, 2, 2, 0, 0]));
+
+    value = CSSStyleValue.parse('transform', 'matrix3d(1, 2, 3, 4, 5, 6, 7, 8.6, 9, 10, 11, 12, 13, 14, 15, 16)');
+    assert.strictEqual(value.cssText, 'matrix3d(1, 2, 3, 4, 5, 6, 7, 8.6, 9, 10, 11, 12, 13, 14, 15, 16)');
+    assert.instanceOf(value.transformComponents[0], CSSMatrix);
+    typedOM.internal.testing.matricesApproxEqual(value.transformComponents[0].matrix, new DOMMatrixReadonly([1, 2, 3, 4, 5, 6, 7, 8.6, 9, 10, 11, 12, 13, 14, 15, 16]));
+  });
+
+  test('parse works for transform(perspective)', function() {
+    var value = CSSStyleValue.parse('transform', 'perspective(10px)');
+    assert.strictEqual(value.cssText, 'perspective(10px)');
+    assert.instanceOf(value.transformComponents[0], CSSPerspective);
+    assert.strictEqual(value.transformComponents[0].length.value, 10);
+    assert.strictEqual(value.transformComponents[0].length.type, 'px');
   });
 
   test('parse should be case insensitive', function() {

--- a/test/js/css-style-value.js
+++ b/test/js/css-style-value.js
@@ -130,10 +130,9 @@ suite('CSSStyleValue', function() {
     assert.strictEqual(value.cssText, 'calc(10px + 3em)');
   });
 
-  //TODO: Renee: Make these check the error string.
   test('parse throws an error if either the property or the cssText is not a string', function() {
-    assert.throws(function() {CSSStyleValue.parse(4, 'auto')}, TypeError, 'Property name must be a string');
-    assert.throws(function() {CSSStyleValue.parse('height', 5)}, TypeError, 'Must parse a string');
+    assert.throws(function() {CSSStyleValue.parse(4, 'auto')}, TypeError, /^Property name must be a string/);
+    assert.throws(function() {CSSStyleValue.parse('height', 5)}, TypeError, /^Must parse a string/);
   });
 
   test('parse returns null if an unsupported property is entered', function() {
@@ -144,7 +143,6 @@ suite('CSSStyleValue', function() {
     assert.isNull(CSSStyleValue.parse('height', '10'));
   });
 
-  //TODO: Renee: Make these check the error string.
   test('instantiating CSSStyleValue throws', function() {
     assert.throws(function() {new CSSStyleValue('10px')}, TypeError, 'CSSStyleValue cannot be instantiated.');
   });

--- a/test/js/css-style-value.js
+++ b/test/js/css-style-value.js
@@ -1,20 +1,20 @@
 suite('CSSStyleValue', function() {
   test('parse successfully creates a CSSKeywordValue object if the cssText is a valid keyword for a property', function() {
-    var keywordValueArray = CSSStyleValue.parse('height', 'auto');
+    var keywordValue  = CSSStyleValue.parse('height', 'auto');
 
-    assert.strictEqual(keywordValueArray[0].cssText, 'auto');
+    assert.strictEqual(keywordValue.cssText, 'auto');
   });
 
   test('parse successfully creates a CSSLengthValue object if the cssText is a valid and the property supports lengthValues', function() {
-    var keywordValueArray = CSSStyleValue.parse('height', 'calc(10px + 3em)');
+    var value = CSSStyleValue.parse('height', 'calc(10px + 3em)');
 
-    assert.strictEqual(keywordValueArray[0].cssText, 'calc(10px + 3em)');
+    assert.strictEqual(value.cssText, 'calc(10px + 3em)');
   });
 
   test('parse should be case insensitive', function() {
-    var keywordValueArray = CSSStyleValue.parse('height', 'CaLc(10px + 3em)');
+    var value = CSSStyleValue.parse('height', 'CaLc(10px + 3em)');
 
-    assert.strictEqual(keywordValueArray[0].cssText, 'calc(10px + 3em)');
+    assert.strictEqual(value.cssText, 'calc(10px + 3em)');
   });
 
   // Skipping until parse is hooked up through methods other than .from

--- a/test/js/property-dictionary.js
+++ b/test/js/property-dictionary.js
@@ -55,25 +55,25 @@ suite('PropertyDictionary', function() {
     assert.isFalse(cssPropertyDictionary.isListValuedProperty('height'));
   });
 
-  test('getListValueSeparator method should return the string used to separate a list of CSSStyleValue strings' +
+  test('listValueSeparator method should return the string used to separate a list of CSSStyleValue strings' +
       'for a given property', function() {
 
-    assert.strictEqual(cssPropertyDictionary.getListValueSeparator('animation-iteration-count'), ', ');
+    assert.strictEqual(cssPropertyDictionary.listValueSeparator('animation-iteration-count'), ', ');
   });
 
-  test('getListValueSeparator method should throw a TypeError if the property entered does not support list values', function() {
+  test('listValueSeparator method should throw a TypeError if the property entered does not support list values', function() {
 
-    assert.throw(function () {cssPropertyDictionary.getListValueSeparator('height')}, TypeError);
+    assert.throw(function () {cssPropertyDictionary.listValueSeparator('height')}, TypeError);
   });
 
-  test('getValidStyleValuesArray should return an array of constructors for all CSSStyleValue types accepted by that property', function() {
-    var styleValueArray = cssPropertyDictionary.getValidStyleValuesArray('height');
+  test('supportedStyleValues should return an array of constructors for all CSSStyleValue types accepted by that property', function() {
+    var styleValueArray = cssPropertyDictionary.supportedStyleValues('height');
 
     assert.strictEqual(styleValueArray[0], CSSLengthValue);
   });
 
-  test('getValidStyleValuesArray should throw a type error for unsupported properties', function() {
+  test('supportedStyleValues should throw a type error for unsupported properties', function() {
 
-    assert.throw(function () {cssPropertyDictionary.getValidStyleValuesArray('lemon');}, TypeError);
+    assert.throw(function () {cssPropertyDictionary.supportedStyleValues('lemon');}, TypeError);
   });
 });


### PR DESCRIPTION
WIP because it needs more tests.

This is an evolution of Eddy's work here https://github.com/css-typed-om/typed-om/pull/132.

We had some consumers returning null and some returning undefined on failure. I've changed them so that they all return null (https://drafts.css-houdini.org/css-typed-om-1/#dom-cssstylevalue-parse).
