### PR TITLE
Remove support for double angles in CSSSkew and CSSRotation constructors

### DIFF
--- a/src/css-rotation.js
+++ b/src/css-rotation.js
@@ -74,15 +74,15 @@
     if (arguments.length != 1 && arguments.length != 4) {
       throw new TypeError('CSSRotation must have 1 or 4 arguments.');
     }
-    if (arguments.length == 1 && (typeof x != 'number' && !(x instanceof CSSAngleValue))) {
-      throw new TypeError('CSSRotation angle argument must be a number or a CSSAngleValue.');
+    if (arguments.length == 1 && !(x instanceof CSSAngleValue)) {
+      throw new TypeError('CSSRotation angle argument must be a CSSAngleValue.');
     }
     if (arguments.length == 4) {
       if (typeof x != 'number' || typeof y != 'number' || typeof z != 'number') {
         throw new TypeError('x, y and z values must be numbers.');
       }
-      if (typeof angle != 'number' && !(angle instanceof CSSAngleValue)) {
-        throw new TypeError('CSSRotation angle argument must be a number or a CSSAngleValue.');
+      if (!(angle instanceof CSSAngleValue)) {
+        throw new TypeError('CSSRotation angle argument must be a CSSAngleValue.');
       }
     }
 
@@ -91,12 +91,7 @@
     this.y = this.is2D ? null : y;
     this.z = this.is2D ? null : z;
     this._inputType = this.is2D ? '2d' : '3d';
-    var angleValue = this.is2D ? x : angle;
-    if (angleValue instanceof CSSAngleValue) {
-      this.angle = angleValue;
-    } else {
-      this.angle = new CSSAngleValue(angleValue, 'deg');
-    }
+    this.angle = this.is2D ? x : angle;
 
     this.matrix = computeMatrix(this);
     Object.defineProperty(this, 'cssText', {

--- a/src/css-skew.js
+++ b/src/css-skew.js
@@ -45,18 +45,12 @@
   function CSSSkew(ax, ay) {
     if (arguments.length != 2) {
       throw new TypeError('CSSSkew must have 2 arguments.');
-    // Arguments must both be CSSAngleValues or both be doubles.
-    } else if (!(ay instanceof CSSAngleValue && ax instanceof CSSAngleValue) && !(typeof ay == 'number' && typeof ax == 'number')) {
-      throw new TypeError('CSSSkew arguments must be all numbers or all CSSAngleValues.');
+    } else if (!(ay instanceof CSSAngleValue && ax instanceof CSSAngleValue)) {
+      throw new TypeError('CSSSkew arguments must be all CSSAngleValues.');
     }
 
-    if (ax instanceof CSSAngleValue) {
-      this.ax = ax;
-      this.ay = ay;
-    } else {
-      this.ax = new CSSAngleValue(ax, 'deg');
-      this.ay = new CSSAngleValue(ay, 'deg');
-    }
+    this.ax = ax;
+    this.ay = ay;
 
     this.matrix = computeMatrix(this);
     this.is2D = this.matrix.is2D;

--- a/test/js/css-rotation.js
+++ b/test/js/css-rotation.js
@@ -8,24 +8,28 @@ suite('CSSRotation', function() {
   }
 
   test('CSSRotation is a CSSRotation and CSSTransformComponent', function() {
-    var rotation = new CSSRotation(45);
+    var rotation = new CSSRotation(new CSSAngleValue(3, 'deg'));
     assert.instanceOf(rotation, CSSRotation);
     assert.instanceOf(rotation, typedOM.internal.CSSTransformComponent);
   });
 
   test('CSSRotation constructor throws exception for invalid types', function() {
-    assert.throws(function() {new CSSRotation()});
-    assert.throws(function() {new CSSRotation({})});
-    assert.throws(function() {new CSSRotation(1, 2)});
-    assert.throws(function() {new CSSRotation(1, 2, 3)});
-    assert.throws(function() {new CSSRotation(1, 2, 3, 4, 5)});
-    assert.throws(function() {new CSSRotation('1')});
-    assert.throws(function() {new CSSRotation(null)});
+    var argCountErr = /^CSSRotation must have 1 or 4 arguments\./;
+    assert.throws(function() {new CSSRotation()}, TypeError, argCountErr);
+    assert.throws(function() {new CSSRotation(1, 2)}, TypeError, argCountErr);
+    assert.throws(function() {new CSSRotation(1, 2, 3)}, TypeError, argCountErr);
+    assert.throws(function() {new CSSRotation(1, 2, 3, 4, 5)}, TypeError, argCountErr);
+    var argTypeErr = /^CSSRotation angle argument must be a CSSAngleValue\./;
+    assert.throws(function() {new CSSRotation({})}, TypeError, argTypeErr);
+    assert.throws(function() {new CSSRotation(1)}, TypeError, argTypeErr);
+    assert.throws(function() {new CSSRotation('1')}, TypeError, argTypeErr);
+    assert.throws(function() {new CSSRotation(null)}, TypeError, argTypeErr);
+    assert.throws(function() {new CSSRotation(1, 2, 3, 4)}, TypeError, argTypeErr);
   });
 
   test('CSSRotation constructor works correctly for 1 argument', function() {
     var rotation;
-    assert.doesNotThrow(function() {rotation = new CSSRotation(60)});
+    assert.doesNotThrow(function() {rotation = new CSSRotation(new CSSAngleValue(60, 'deg'))});
     assert.strictEqual(rotation.cssText, 'rotate(60deg)');
     assert.strictEqual(rotation.angle._value, 60);
     assert.strictEqual(rotation.angle._unit, 'deg');
@@ -46,24 +50,7 @@ suite('CSSRotation', function() {
     assert.strictEqual(rotation.angle._unit, 'rad');
   });
 
-  test('CSSRotation constructor works correctly for 4 arguments, number angle', function() {
-    var rotation;
-    assert.doesNotThrow(function() {rotation = new CSSRotation(1, 0.5, -2, 30)});
-    assert.strictEqual(rotation.cssText, 'rotate3d(1, 0.5, -2, 30deg)');
-    assert.strictEqual(rotation.angle._value, 30);
-    assert.strictEqual(rotation.angle._unit, 'deg');
-    assert.strictEqual(rotation.x, 1);
-    assert.strictEqual(rotation.y, 0.5);
-    assert.strictEqual(rotation.z, -2);
-    assert.isFalse(rotation.is2D);
-
-    var expectedMatrix = new DOMMatrixReadonly([0.89154437, -0.42367629, -0.16014688, 0,
-        0.44919526, 0.872405146, 0.19269891, 0, 0.05807100, -0.243736860,
-        0.96810128, 0, 0, 0, 0, 1]);
-    typedOM.internal.testing.matricesApproxEqual(rotation.matrix, expectedMatrix);
-  });
-
-  test('CSSRotation constructor works correctly for 4 arguments, CSSAngleValue angle', function() {
+  test('CSSRotation constructor works correctly for 4 arguments', function() {
     var rotation;
     assert.doesNotThrow(function() {rotation = new CSSRotation(1, 0.5, -2, new CSSAngleValue(0.0833333, 'turn'))});
     assert.strictEqual(rotation.cssText, 'rotate3d(1, 0.5, -2, 0.0833333turn)');
@@ -81,49 +68,34 @@ suite('CSSRotation', function() {
   });
 
   test('CSSRotation matrix with angle 0 is the identity', function() {
-    var rotation2D = new CSSRotation(0);
+    var rotation2D = new CSSRotation(new CSSAngleValue(0, 'deg'));
     var expected2D = new DOMMatrixReadonly([1, 0, 0, 1, 0, 0]);
     typedOM.internal.testing.matricesApproxEqual(rotation2D.matrix, expected2D);
 
-    var rotation3D = new CSSRotation(20, -5, 10, 0);
+    var rotation3D = new CSSRotation(20, -5, 10, new CSSAngleValue(0, 'deg'));
     var expected3D = new DOMMatrixReadonly([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]);
     typedOM.internal.testing.matricesApproxEqual(rotation3D.matrix, expected3D);
   });
 
   test('CSSRotation matrix with x, y, and z all 0 is the identity', function() {
-    var rotation = new CSSRotation(0, 0, 0, 45);
+    var rotation = new CSSRotation(0, 0, 0, new CSSAngleValue(45, 'deg'));
     var expectedMatrix = new DOMMatrixReadonly([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0,
         1]);
     typedOM.internal.testing.matricesApproxEqual(rotation.matrix, expectedMatrix);
   });
 
   test('CSSRotation(angle) equivalent to CSSRotation(0, 0, 1, angle)', function() {
-    var rotation2D = new CSSRotation(30);
-    var rotation3D = new CSSRotation(0, 0, 1, 30);
+    var rotation2D = new CSSRotation(new CSSAngleValue(30, 'deg'));
+    var rotation3D = new CSSRotation(0, 0, 1, new CSSAngleValue(30, 'deg'));
     assert.isTrue(rotation2D.is2D);
     assert.isFalse(rotation3D.is2D);
     typedOM.internal.testing.matricesApproxEqual(rotation3D.matrix, rotation2D.matrix);
   });
 
   test('CSSRotation 3D is normalizing (x, y, z)', function() {
-    var rotation = new CSSRotation(1, -2, 4, 30);
-    var rotationScaled = new CSSRotation(10, -20, 40, 30);
+    var rotation = new CSSRotation(1, -2, 4, new CSSAngleValue(30, 'deg'));
+    var rotationScaled = new CSSRotation(10, -20, 40, new CSSAngleValue(30, 'deg'));
     typedOM.internal.testing.matricesApproxEqual(rotationScaled.matrix, rotation.matrix);
-  });
-
-  test('CSSRotation using CSSAngleValue is equivalent to taking a number for angle for 2D case', function() {
-    var rotationAngleValue = new CSSRotation(new CSSAngleValue(20, 'deg'));
-    var rotationNumberValue = new CSSRotation(20);
-    assert.deepEqual(rotationAngleValue.angle, rotationNumberValue.angle);
-    typedOM.internal.testing.matricesApproxEqual(rotationAngleValue.matrix, rotationNumberValue.matrix);
-  });
-
-  test('CSSRotation using CSSAngleValue is equivalent to taking a number for angle for 3D case', function() {
-    var rotationAngleValue = new CSSRotation(1, 2, 3, new CSSAngleValue(20, 'deg'));
-    var rotationNumberValue = new CSSRotation(1, 2, 3, 20);
-    assert.isFalse(rotationAngleValue.is2D);
-    assert.deepEqual(rotationAngleValue.angle, rotationNumberValue.angle);
-    typedOM.internal.testing.matricesApproxEqual(rotationAngleValue.matrix, rotationNumberValue.matrix);
   });
 
   test('Parsing valid basic strings results in CSSRotation with correct values', function() {

--- a/test/js/css-skew.js
+++ b/test/js/css-skew.js
@@ -1,26 +1,25 @@
 suite('CSSSkew', function() {
 
   test('CSSSkew constructor throws exception for invalid types', function() {
-    argCountErr = /^CSSSkew must have 2 arguments\./;
+    var argCountErr = /^CSSSkew must have 2 arguments\./;
     assert.throws(function() {new CSSSkew()}, TypeError, argCountErr);
     assert.throws(function() {new CSSSkew({})}, TypeError, argCountErr);
-    assert.throws(function() {new CSSSkew(1)}, TypeError, argCountErr);
-    assert.throws(function() {new CSSSkew(1, 2, 3)}, TypeError, argCountErr);
-    var argTypeErr = /^CSSSkew arguments must be all numbers or all CSSAngleValues\./;
+    assert.throws(function() {new CSSSkew(new CSSAngleValue(2, 'deg'))}, TypeError, argCountErr);
+    assert.throws(function() {new CSSSkew(new CSSAngleValue(1, 'deg'), new CSSAngleValue(2, 'deg'), new CSSAngleValue(3, 'deg'))}, TypeError, argCountErr);
+    var argTypeErr = /^CSSSkew arguments must be all CSSAngleValues\./;
     assert.throws(function() {new CSSSkew({}, {})}, TypeError, argTypeErr);
     assert.throws(function() {new CSSSkew('1', '2')}, TypeError, argTypeErr);
+    assert.throws(function() {new CSSSkew(1, 2)}, TypeError, argTypeErr);
     assert.throws(function() {new CSSSkew(1, new CSSAngleValue(2, 'deg'))}, TypeError, argTypeErr);
     assert.throws(function() {new CSSSkew(3, null)}, TypeError, argTypeErr);
   });
 
   test('CSSSkew constructor works correctly', function() {
     var values = [
-      new CSSSkew(30, 180),
       new CSSSkew(new CSSAngleValue(30, 'deg'), new CSSAngleValue(180, 'deg')),
       new CSSSkew(new CSSAngleValue(0.52359878, 'rad'), new CSSAngleValue(3.14159265, 'rad'))
     ];
     var expectations = [
-      {cssText: 'skew(30deg, 180deg)', xValue: 30, xUnit: 'deg', yValue: 180, yUnit: 'deg'},
       {cssText: 'skew(30deg, 180deg)', xValue: 30, xUnit: 'deg', yValue: 180, yUnit: 'deg'},
       {cssText: 'skew(0.52359878rad, 3.14159265rad)', xValue: 0.52359878, xUnit: 'rad', yValue: 3.14159265, yUnit: 'rad'}
     ];

--- a/test/js/css-transform-value.js
+++ b/test/js/css-transform-value.js
@@ -14,7 +14,7 @@ suite('CSSTransformValue', function() {
     assert.throws(function() {new CSSTransformValue([new CSSNumberValue(5)])});
   });
 
-  test('Empty CSSTransformValue constructor creates an object with ' + 
+  test('Empty CSSTransformValue constructor creates an object with ' +
     'empty cssText, 2D identity matrix', function() {
     var transform = new CSSTransformValue();
     assert.isTrue(transform.is2D);
@@ -74,7 +74,7 @@ suite('CSSTransformValue', function() {
     var transform;
     var matrix2d = new CSSMatrix(new DOMMatrixReadonly([1, 2, 3, 4, 5, 6]));
     var matrix3d = new CSSMatrix(new DOMMatrixReadonly([1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6]));
-    var skew = new CSSSkew(30, 60);
+    var skew = new CSSSkew(new CSSAngleValue(30, 'deg'), new CSSAngleValue(60, 'deg'));
     var scale2d = new CSSScale(2, -1);
     var scale3d = new CSSScale(3, 2, 0.5);
     var values = [matrix2d, scale3d, matrix2d, skew, matrix3d, scale2d];
@@ -103,7 +103,7 @@ suite('CSSTransformValue', function() {
   });
 
   test('Parsing string with multiple components results in CSSTransformValue with correct values', function() {
-    var expectedComponents = [new CSSRotation(20), new CSSPerspective(new CSSSimpleLength(5, 'px'))];
+    var expectedComponents = [new CSSRotation(new CSSAngleValue(20, 'deg')), new CSSPerspective(new CSSSimpleLength(5, 'px'))];
     var result = typedOM.internal.parsing.consumeTransformValue('rotate(20deg) perspective(5px) foo');
     assert.isNotNull(result);
     assert.strictEqual(result[1], 'foo');


### PR DESCRIPTION
As per spec change here https://github.com/w3c/css-houdini-drafts/pull/280 
