### PR TITLE
Update CSSTranslation.cssText to new style

### DIFF
--- a/src/css-translation.js
+++ b/src/css-translation.js
@@ -32,7 +32,9 @@
 
   function generateCssString(cssTranslation) {
     if (cssTranslation.is2D) {
-      return 'translate(' + cssTranslation.x.cssText + ', ' + cssTranslation.y.cssText + ')';
+      return 'translate('
+        + cssTranslation.x.cssText + ', '
+        + cssTranslation.y.cssText + ')';
     } else {
       return 'translate3d('
         + cssTranslation.x.cssText + ', '
@@ -71,6 +73,7 @@
       set: function(newCssText) {}
     });
   }
+  internal.inherit(CSSTranslation, internal.CSSTransformComponent);
 
   // These functions (cssTranslationFromTranslate*) are for making CSSTranslations from parsed CSS
   // Strings. These are needed for setting the cssText.
@@ -125,7 +128,6 @@
     return result;
   }
 
-  internal.inherit(CSSTranslation, internal.CSSTransformComponent);
   internal.cssTranslationFromTranslate = cssTranslationFromTranslate;
   internal.cssTranslationFromTranslate3d = cssTranslationFromTranslate3d;
   internal.cssTranslationFromTranslateX = cssTranslationFromTranslateX;

--- a/src/css-translation.js
+++ b/src/css-translation.js
@@ -31,15 +31,23 @@
   };
 
   function generateCssString(cssTranslation) {
-    var cssText;
-    if (cssTranslation.is2D) {
-      cssText = 'translate(' + cssTranslation.x.cssText + ', '
-          + cssTranslation.y.cssText + ')';
-    } else {
-      cssText = 'translate3d(' + cssTranslation.x.cssText + ', '
-          + cssTranslation.y.cssText + ', ' + cssTranslation.z.cssText + ')';
+    switch (cssTranslation._inputType) {
+      case '1':
+        return 'translate(' + cssTranslation.x.cssText + ')';
+      case '2':
+        return 'translate(' + cssTranslation.x.cssText + ', ' + cssTranslation.y.cssText + ')';
+      case '3':
+        return 'translate3d('
+          + cssTranslation.x.cssText + ', '
+          + cssTranslation.y.cssText + ', '
+          + cssTranslation.z.cssText + ')';
+      case 'x':
+        return 'translatex(' + cssTranslation.x.cssText + ')';
+      case 'y':
+        return 'translatey(' + cssTranslation.y.cssText + ')';
+      case 'z':
+        return 'translatez(' + cssTranslation.z.cssText + ')';
     }
-    return cssText;
   };
 
   function CSSTranslation(x, y, z) {
@@ -57,11 +65,26 @@
 
     this.x = new CSSSimpleLength(x);
     this.y = new CSSSimpleLength(y);
-    this.z = (z instanceof CSSSimpleLength) ? new CSSSimpleLength(z) : null;
+    if (z instanceof CSSSimpleLength) {
+      this.z = new CSSSimpleLength(z);
+      this._inputType = '3';
+    } else {
+      this.z = null;
+      this._inputType = '2';
+    }
 
     this.matrix = computeMatrix(this);
     this.is2D = this.matrix.is2D;
-    this.cssText = generateCssString(this);
+
+    Object.defineProperty(this, 'cssText', {
+      get: function() {
+        if (!this._cssText) {
+          this._cssText = generateCssString(this);
+        }
+        return this._cssText;
+      },
+      set: function(newCssText) {}
+    });
   }
   internal.inherit(CSSTranslation, internal.CSSTransformComponent);
 

--- a/src/css-translation.js
+++ b/src/css-translation.js
@@ -30,22 +30,24 @@
     return matrix;
   };
 
-  function generateCssString(cssTranslation) {
-    switch (cssTranslation._inputType) {
-      case '1':
+  function generateTranslationCssString(cssTranslation, inputType) {
+    switch (inputType) {
+      case internal.parsing.inputStringType._1D:
+        console.log('1D');
         return 'translate(' + cssTranslation.x.cssText + ')';
-      case '2':
+      case internal.parsing.inputStringType._2D:
+        console.log('2D');
         return 'translate(' + cssTranslation.x.cssText + ', ' + cssTranslation.y.cssText + ')';
-      case '3':
+      case internal.parsing.inputStringType._3D:
         return 'translate3d('
           + cssTranslation.x.cssText + ', '
           + cssTranslation.y.cssText + ', '
           + cssTranslation.z.cssText + ')';
-      case 'x':
+      case internal.parsing.inputStringType._X:
         return 'translatex(' + cssTranslation.x.cssText + ')';
-      case 'y':
+      case internal.parsing.inputStringType._Y:
         return 'translatey(' + cssTranslation.y.cssText + ')';
-      case 'z':
+      case internal.parsing.inputStringType._Z:
         return 'translatez(' + cssTranslation.z.cssText + ')';
     }
   };
@@ -67,10 +69,10 @@
     this.y = new CSSSimpleLength(y);
     if (z instanceof CSSSimpleLength) {
       this.z = new CSSSimpleLength(z);
-      this._inputType = '3';
+      // this._inputType = '3';
     } else {
       this.z = null;
-      this._inputType = '2';
+      // this._inputType = '2';
     }
 
     this.matrix = computeMatrix(this);
@@ -79,7 +81,8 @@
     Object.defineProperty(this, 'cssText', {
       get: function() {
         if (!this._cssText) {
-          this._cssText = generateCssString(this);
+          console.log('set cssText' + this);
+          this._cssText = this.is2D ? generateTranslationCssString(this, internal.parsing.inputStringType._2D) : generateTranslationCssString(this, internal.parsing.inputStringType._3D);
         }
         return this._cssText;
       },
@@ -87,6 +90,7 @@
     });
   }
   internal.inherit(CSSTranslation, internal.CSSTransformComponent);
+  internal.generateTranslationCssString = generateTranslationCssString;
 
   scope.CSSTranslation = CSSTranslation;
 

--- a/src/css-translation.js
+++ b/src/css-translation.js
@@ -30,25 +30,14 @@
     return matrix;
   };
 
-  function generateTranslationCssString(cssTranslation, inputType) {
-    switch (inputType) {
-      case internal.parsing.inputStringType._1D:
-        console.log('1D');
-        return 'translate(' + cssTranslation.x.cssText + ')';
-      case internal.parsing.inputStringType._2D:
-        console.log('2D');
-        return 'translate(' + cssTranslation.x.cssText + ', ' + cssTranslation.y.cssText + ')';
-      case internal.parsing.inputStringType._3D:
-        return 'translate3d('
-          + cssTranslation.x.cssText + ', '
-          + cssTranslation.y.cssText + ', '
-          + cssTranslation.z.cssText + ')';
-      case internal.parsing.inputStringType._X:
-        return 'translatex(' + cssTranslation.x.cssText + ')';
-      case internal.parsing.inputStringType._Y:
-        return 'translatey(' + cssTranslation.y.cssText + ')';
-      case internal.parsing.inputStringType._Z:
-        return 'translatez(' + cssTranslation.z.cssText + ')';
+  function generateCssString(cssTranslation) {
+    if (cssTranslation.is2D) {
+      return 'translate(' + cssTranslation.x.cssText + ', ' + cssTranslation.y.cssText + ')';
+    } else {
+      return 'translate3d('
+        + cssTranslation.x.cssText + ', '
+        + cssTranslation.y.cssText + ', '
+        + cssTranslation.z.cssText + ')';
     }
   };
 
@@ -67,13 +56,7 @@
 
     this.x = new CSSSimpleLength(x);
     this.y = new CSSSimpleLength(y);
-    if (z instanceof CSSSimpleLength) {
-      this.z = new CSSSimpleLength(z);
-      // this._inputType = '3';
-    } else {
-      this.z = null;
-      // this._inputType = '2';
-    }
+    this.z = (z instanceof CSSSimpleLength) ? new CSSSimpleLength(z) : null;
 
     this.matrix = computeMatrix(this);
     this.is2D = this.matrix.is2D;
@@ -81,8 +64,7 @@
     Object.defineProperty(this, 'cssText', {
       get: function() {
         if (!this._cssText) {
-          console.log('set cssText' + this);
-          this._cssText = this.is2D ? generateTranslationCssString(this, internal.parsing.inputStringType._2D) : generateTranslationCssString(this, internal.parsing.inputStringType._3D);
+          this._cssText = generateCssString(this);
         }
         return this._cssText;
       },
@@ -90,7 +72,6 @@
     });
   }
   internal.inherit(CSSTranslation, internal.CSSTransformComponent);
-  internal.generateTranslationCssString = generateTranslationCssString;
 
   scope.CSSTranslation = CSSTranslation;
 

--- a/src/css-translation.js
+++ b/src/css-translation.js
@@ -71,7 +71,65 @@
       set: function(newCssText) {}
     });
   }
+
+  // These functions (cssTranslationFromTranslate*) are for making CSSTranslations from parsed CSS Strings. These are needed for setting the cssText.
+  function cssTranslationFromTranslate(coords, string, remaining) {
+    if (coords.length == 1) {
+      var result = [new CSSTranslation(coords[0], new CSSSimpleLength(0, 'px')), remaining];
+      result[0]._cssText = string;
+      return result;
+    }
+    if (coords.length == 2) {
+      var result = [new CSSTranslation(coords[0], coords[1]), remaining];
+      result[0]._cssText = string;
+      return result;
+    }
+    return null;
+  }
+
+  function cssTranslationFromTranslate3d(coords, string, remaining) {
+    if (coords.length != 3) {
+      return null;
+    }
+    var result = [new CSSTranslation(coords[0], coords[1], coords[2]), remaining];
+    result[0]._cssText = string;
+    return result;
+  }
+
+  function cssTranslationFromTranslateX(coords, string, remaining) {
+    if (coords.length != 1) {
+      return null;
+    }
+    var result = [new CSSTranslation(coords[0], new CSSSimpleLength(0, 'px')), remaining];
+    result[0]._cssText = string;
+    return result;
+  }
+
+  function cssTranslationFromTranslateY(coords, string, remaining) {
+    if (coords.length != 1) {
+      return null;
+    }
+    var result = [new CSSTranslation(new CSSSimpleLength(0, 'px'), coords[0]), remaining];
+    result[0]._cssText = string;
+    return result;
+  }
+
+  function cssTranslationFromTranslateZ(coords, string, remaining) {
+    if (coords.length != 1) {
+      return null;
+    }
+    var zeroLength = new CSSSimpleLength(0, 'px');
+    var result = [new CSSTranslation(zeroLength, zeroLength, coords[0]), remaining];
+    result[0]._cssText = string;
+    return result;
+  }
+
   internal.inherit(CSSTranslation, internal.CSSTransformComponent);
+  internal.cssTranslationFromTranslate = cssTranslationFromTranslate;
+  internal.cssTranslationFromTranslate3d = cssTranslationFromTranslate3d;
+  internal.cssTranslationFromTranslateX = cssTranslationFromTranslateX;
+  internal.cssTranslationFromTranslateY = cssTranslationFromTranslateY;
+  internal.cssTranslationFromTranslateZ = cssTranslationFromTranslateZ;
 
   scope.CSSTranslation = CSSTranslation;
 

--- a/src/css-translation.js
+++ b/src/css-translation.js
@@ -72,7 +72,8 @@
     });
   }
 
-  // These functions (cssTranslationFromTranslate*) are for making CSSTranslations from parsed CSS Strings. These are needed for setting the cssText.
+  // These functions (cssTranslationFromTranslate*) are for making CSSTranslations from parsed CSS
+  // Strings. These are needed for setting the cssText.
   function cssTranslationFromTranslate(coords, string, remaining) {
     if (coords.length == 1) {
       var result = [new CSSTranslation(coords[0], new CSSSimpleLength(0, 'px')), remaining];

--- a/src/parsing/css-translation-parsing.js
+++ b/src/parsing/css-translation-parsing.js
@@ -15,16 +15,16 @@
 (function(internal) {
   var parsing = internal.parsing;
 
-  function translate3d(coords, remaining) {
+  function translate3d(coords, string, remaining) {
       if (coords.length != 3) {
         return null;
       }
       var result = [new CSSTranslation(coords[0], coords[1], coords[2]), remaining];
-      result[0]._cssText = internal.generateTranslationCssString(result[0], internal.parsing.inputStringType._3D);
+      result[0]._cssText = string;
       return result;
   }
 
-  function translateXYorZ(type, coords, remaining) {
+  function translateXYorZ(type, coords, string, remaining) {
     if (coords.length != 1) {
       return null;
     }
@@ -32,15 +32,15 @@
     switch (type) {
       case 'x':
         var result = [new CSSTranslation(coords[0], zeroLength), remaining];
-        result[0]._cssText = internal.generateTranslationCssString(result[0], internal.parsing.inputStringType._X);
+        result[0]._cssText = string;
         return result;
       case 'y':
         var result = [new CSSTranslation(zeroLength, coords[0]), remaining];
-        result[0]._cssText = internal.generateTranslationCssString(result[0], internal.parsing.inputStringType._Y);
+        result[0]._cssText = string;
         return result;
       case 'z':
         var result = [new CSSTranslation(zeroLength, zeroLength, coords[0]), remaining];
-        result[0]._cssText = internal.generateTranslationCssString(result[0], internal.parsing.inputStringType._Z);
+        result[0]._cssText = string;
         return result;
     }
     return null;
@@ -70,22 +70,22 @@
 
     switch (type) {
       case '3d' :
-        return translate3d(coords, remaining);
+        return translate3d(coords, string, remaining);
       case 'x':
       case 'y':
       case 'z':
-        return translateXYorZ(type, coords, remaining);
+        return translateXYorZ(type, coords, string, remaining);
     }
 
     // Only translate(x) and translate(x, y) remain.
     if (coords.length == 1) {
       var result = [new CSSTranslation(coords[0], new CSSSimpleLength(0, 'px')), remaining];
-      result[0]._cssText = internal.generateTranslationCssString(result[0], internal.parsing.inputStringType._1D);
+      result[0]._cssText = string;
       return result;
     }
     if (coords.length == 2) {
       var result = [new CSSTranslation(coords[0], coords[1]), remaining];
-      result[0]._cssText = internal.generateTranslationCssString(result[0], internal.parsing.inputStringType._2D);
+      result[0]._cssText = string;
       return result;
     }
     return null;

--- a/src/parsing/css-translation-parsing.js
+++ b/src/parsing/css-translation-parsing.js
@@ -15,57 +15,6 @@
 (function(internal) {
   var parsing = internal.parsing;
 
-  function translationFromTranslate(coords, string, remaining) {
-    if (coords.length == 1) {
-      var result = [new CSSTranslation(coords[0], new CSSSimpleLength(0, 'px')), remaining];
-      result[0]._cssText = string;
-      return result;
-    }
-    if (coords.length == 2) {
-      var result = [new CSSTranslation(coords[0], coords[1]), remaining];
-      result[0]._cssText = string;
-      return result;
-    }
-    return null;
-  }
-
-  function translationFromTranslate3d(coords, string, remaining) {
-    if (coords.length != 3) {
-      return null;
-    }
-    var result = [new CSSTranslation(coords[0], coords[1], coords[2]), remaining];
-    result[0]._cssText = string;
-    return result;
-  }
-
-  function translationFromTranslateX(coords, string, remaining) {
-    if (coords.length != 1) {
-      return null;
-    }
-    var result = [new CSSTranslation(coords[0], new CSSSimpleLength(0, 'px')), remaining];
-    result[0]._cssText = string;
-    return result;
-  }
-
-  function translationFromTranslateY(coords, string, remaining) {
-    if (coords.length != 1) {
-      return null;
-    }
-    var result = [new CSSTranslation(new CSSSimpleLength(0, 'px'), coords[0]), remaining];
-    result[0]._cssText = string;
-    return result;
-  }
-
-  function translationFromTranslateZ(coords, string, remaining) {
-    if (coords.length != 1) {
-      return null;
-    }
-    var zeroLength = new CSSSimpleLength(0, 'px');
-    var result = [new CSSTranslation(zeroLength, zeroLength, coords[0]), remaining];
-    result[0]._cssText = string;
-    return result;
-  }
-
   function consumeTranslation(string) {
     var params = parsing.consumeList([
         parsing.ignore(parsing.consumeToken.bind(null, /^translate/i)),
@@ -90,16 +39,16 @@
 
     switch (type) {
       case '3d' :
-        return translationFromTranslate3d(coords, string, remaining);
+        return internal.cssTranslationFromTranslate3d(coords, string, remaining);
       case 'x':
-        return translationFromTranslateX(coords, string, remaining);
+        return internal.cssTranslationFromTranslateX(coords, string, remaining);
       case 'y':
-        return translationFromTranslateY(coords, string, remaining);
+        return internal.cssTranslationFromTranslateY(coords, string, remaining);
       case 'z':
-        return translationFromTranslateZ(coords, string, remaining);
+        return internal.cssTranslationFromTranslateZ(coords, string, remaining);
     }
 
-    return translationFromTranslate(coords, string, remaining);
+    return internal.cssTranslationFromTranslate(coords, string, remaining);
   }
 
   internal.parsing.consumeTranslation = consumeTranslation;

--- a/src/parsing/css-translation-parsing.js
+++ b/src/parsing/css-translation-parsing.js
@@ -20,7 +20,7 @@
         return null;
       }
       var result = [new CSSTranslation(coords[0], coords[1], coords[2]), remaining];
-      result[0]._inputType = '3';
+      result[0]._cssText = internal.generateTranslationCssString(result[0], internal.parsing.inputStringType._3D);
       return result;
   }
 
@@ -32,15 +32,15 @@
     switch (type) {
       case 'x':
         var result = [new CSSTranslation(coords[0], zeroLength), remaining];
-        result[0]._inputType = 'x';
+        result[0]._cssText = internal.generateTranslationCssString(result[0], internal.parsing.inputStringType._X);
         return result;
       case 'y':
         var result = [new CSSTranslation(zeroLength, coords[0]), remaining];
-        result[0]._inputType = 'y';
+        result[0]._cssText = internal.generateTranslationCssString(result[0], internal.parsing.inputStringType._Y);
         return result;
       case 'z':
         var result = [new CSSTranslation(zeroLength, zeroLength, coords[0]), remaining];
-        result[0]._inputType = 'z';
+        result[0]._cssText = internal.generateTranslationCssString(result[0], internal.parsing.inputStringType._Z);
         return result;
     }
     return null;
@@ -80,12 +80,12 @@
     // Only translate(x) and translate(x, y) remain.
     if (coords.length == 1) {
       var result = [new CSSTranslation(coords[0], new CSSSimpleLength(0, 'px')), remaining];
-      result[0]._inputType = '1';
+      result[0]._cssText = internal.generateTranslationCssString(result[0], internal.parsing.inputStringType._1D);
       return result;
     }
     if (coords.length == 2) {
       var result = [new CSSTranslation(coords[0], coords[1]), remaining];
-      result[0]._inputType = '2';
+      result[0]._cssText = internal.generateTranslationCssString(result[0], internal.parsing.inputStringType._2D);
       return result;
     }
     return null;

--- a/src/parsing/css-translation-parsing.js
+++ b/src/parsing/css-translation-parsing.js
@@ -48,6 +48,7 @@
         return internal.cssTranslationFromTranslateZ(coords, string, remaining);
     }
 
+    // Only translate(s) and translate(x, y) remain.
     return internal.cssTranslationFromTranslate(coords, string, remaining);
   }
 

--- a/src/parsing/css-translation-parsing.js
+++ b/src/parsing/css-translation-parsing.js
@@ -15,35 +15,55 @@
 (function(internal) {
   var parsing = internal.parsing;
 
-  function translate3d(coords, string, remaining) {
-      if (coords.length != 3) {
-        return null;
-      }
-      var result = [new CSSTranslation(coords[0], coords[1], coords[2]), remaining];
+  function translationFromTranslate(coords, string, remaining) {
+    if (coords.length == 1) {
+      var result = [new CSSTranslation(coords[0], new CSSSimpleLength(0, 'px')), remaining];
       result[0]._cssText = string;
       return result;
+    }
+    if (coords.length == 2) {
+      var result = [new CSSTranslation(coords[0], coords[1]), remaining];
+      result[0]._cssText = string;
+      return result;
+    }
+    return null;
   }
 
-  function translateXYorZ(type, coords, string, remaining) {
+  function translationFromTranslate3d(coords, string, remaining) {
+    if (coords.length != 3) {
+      return null;
+    }
+    var result = [new CSSTranslation(coords[0], coords[1], coords[2]), remaining];
+    result[0]._cssText = string;
+    return result;
+  }
+
+  function translationFromTranslateX(coords, string, remaining) {
+    if (coords.length != 1) {
+      return null;
+    }
+    var result = [new CSSTranslation(coords[0], new CSSSimpleLength(0, 'px')), remaining];
+    result[0]._cssText = string;
+    return result;
+  }
+
+  function translationFromTranslateY(coords, string, remaining) {
+    if (coords.length != 1) {
+      return null;
+    }
+    var result = [new CSSTranslation(new CSSSimpleLength(0, 'px'), coords[0]), remaining];
+    result[0]._cssText = string;
+    return result;
+  }
+
+  function translationFromTranslateZ(coords, string, remaining) {
     if (coords.length != 1) {
       return null;
     }
     var zeroLength = new CSSSimpleLength(0, 'px');
-    switch (type) {
-      case 'x':
-        var result = [new CSSTranslation(coords[0], zeroLength), remaining];
-        result[0]._cssText = string;
-        return result;
-      case 'y':
-        var result = [new CSSTranslation(zeroLength, coords[0]), remaining];
-        result[0]._cssText = string;
-        return result;
-      case 'z':
-        var result = [new CSSTranslation(zeroLength, zeroLength, coords[0]), remaining];
-        result[0]._cssText = string;
-        return result;
-    }
-    return null;
+    var result = [new CSSTranslation(zeroLength, zeroLength, coords[0]), remaining];
+    result[0]._cssText = string;
+    return result;
   }
 
   function consumeTranslation(string) {
@@ -70,25 +90,16 @@
 
     switch (type) {
       case '3d' :
-        return translate3d(coords, string, remaining);
+        return translationFromTranslate3d(coords, string, remaining);
       case 'x':
+        return translationFromTranslateX(coords, string, remaining);
       case 'y':
+        return translationFromTranslateY(coords, string, remaining);
       case 'z':
-        return translateXYorZ(type, coords, string, remaining);
+        return translationFromTranslateZ(coords, string, remaining);
     }
 
-    // Only translate(x) and translate(x, y) remain.
-    if (coords.length == 1) {
-      var result = [new CSSTranslation(coords[0], new CSSSimpleLength(0, 'px')), remaining];
-      result[0]._cssText = string;
-      return result;
-    }
-    if (coords.length == 2) {
-      var result = [new CSSTranslation(coords[0], coords[1]), remaining];
-      result[0]._cssText = string;
-      return result;
-    }
-    return null;
+    return translationFromTranslate(coords, string, remaining);
   }
 
   internal.parsing.consumeTranslation = consumeTranslation;

--- a/src/parsing/css-translation-parsing.js
+++ b/src/parsing/css-translation-parsing.js
@@ -19,7 +19,9 @@
       if (coords.length != 3) {
         return null;
       }
-      return [new CSSTranslation(coords[0], coords[1], coords[2]), remaining];
+      var result = [new CSSTranslation(coords[0], coords[1], coords[2]), remaining];
+      result[0]._inputType = '3';
+      return result;
   }
 
   function translateXYorZ(type, coords, remaining) {
@@ -29,11 +31,17 @@
     var zeroLength = new CSSSimpleLength(0, 'px');
     switch (type) {
       case 'x':
-        return [new CSSTranslation(coords[0], zeroLength), remaining];
+        var result = [new CSSTranslation(coords[0], zeroLength), remaining];
+        result[0]._inputType = 'x';
+        return result;
       case 'y':
-        return [new CSSTranslation(zeroLength, coords[0]), remaining];
+        var result = [new CSSTranslation(zeroLength, coords[0]), remaining];
+        result[0]._inputType = 'y';
+        return result;
       case 'z':
-        return [new CSSTranslation(zeroLength, zeroLength, coords[0]), remaining];
+        var result = [new CSSTranslation(zeroLength, zeroLength, coords[0]), remaining];
+        result[0]._inputType = 'z';
+        return result;
     }
     return null;
   }
@@ -71,10 +79,14 @@
 
     // Only translate(x) and translate(x, y) remain.
     if (coords.length == 1) {
-      return [new CSSTranslation(coords[0], new CSSSimpleLength(0, 'px')), remaining];
+      var result = [new CSSTranslation(coords[0], new CSSSimpleLength(0, 'px')), remaining];
+      result[0]._inputType = '1';
+      return result;
     }
     if (coords.length == 2) {
-      return [new CSSTranslation(coords[0], coords[1]), remaining];
+      var result = [new CSSTranslation(coords[0], coords[1]), remaining];
+      result[0]._inputType = '2';
+      return result;
     }
     return null;
   }

--- a/src/parsing/parsing.js
+++ b/src/parsing/parsing.js
@@ -14,15 +14,6 @@
 
 (function(internal) {
 
-  var inputStringType = {
-    _1D: '1D',
-    _2D: '2D',
-    _3D: '3D',
-    _X: 'X',
-    _Y: 'Y',
-    _Z: 'Z',
-  };
-
   // Extra backslashes because otherwise JS interprets them incorrectly.
   var numberValueRegexStr = '[-+]?(\\d*\\.)?\\d+(e[-+]?\\d+)?';
 
@@ -155,5 +146,4 @@
   internal.parsing.consumeRepeated = consumeRepeated;
   internal.parsing.consumeList = consumeList;
   internal.parsing.consumeParenthesised = consumeParenthesised;
-  internal.parsing.inputStringType = inputStringType;
 })(typedOM.internal);

--- a/src/parsing/parsing.js
+++ b/src/parsing/parsing.js
@@ -14,6 +14,15 @@
 
 (function(internal) {
 
+  var inputStringType = {
+    _1D: '1D',
+    _2D: '2D',
+    _3D: '3D',
+    _X: 'X',
+    _Y: 'Y',
+    _Z: 'Z',
+  };
+
   // Extra backslashes because otherwise JS interprets them incorrectly.
   var numberValueRegexStr = '[-+]?(\\d*\\.)?\\d+(e[-+]?\\d+)?';
 
@@ -146,4 +155,5 @@
   internal.parsing.consumeRepeated = consumeRepeated;
   internal.parsing.consumeList = consumeList;
   internal.parsing.consumeParenthesised = consumeParenthesised;
+  internal.parsing.inputStringType = inputStringType;
 })(typedOM.internal);

--- a/test/js/css-style-value.js
+++ b/test/js/css-style-value.js
@@ -23,9 +23,8 @@ suite('CSSStyleValue', function() {
   });
 
   test('parse works for transform(translate)', function() {
-    var value = CSSStyleValue.parse('transform', 'translate(10px)');
-    // TODO: Change cssText for CSSTranslation so that it reflects parsed string.
-    assert.strictEqual(value.cssText, 'translate(10px, 0px)');
+    var value = CSSStyleValue.parse('transform', 'translate(10PX)');
+    assert.strictEqual(value.cssText, 'translate(10px)');
     assert.instanceOf(value.transformComponents[0], CSSTranslation);
     assert.strictEqual(value.transformComponents[0].x.value, 10);
     assert.strictEqual(value.transformComponents[0].x.type, 'px');
@@ -34,8 +33,8 @@ suite('CSSStyleValue', function() {
     // TODO: Change this to something sensible. Udate spec?
     assert.isNull(value.transformComponents[0].z);
 
-    value = CSSStyleValue.parse('transform', 'translatez(1px)');
-    assert.strictEqual(value.cssText, 'translate3d(0px, 0px, 1px)');
+    value = CSSStyleValue.parse('transform', 'translateZ(1px)');
+    assert.strictEqual(value.cssText, 'translatez(1px)');
     assert.instanceOf(value.transformComponents[0], CSSTranslation);
     assert.strictEqual(value.transformComponents[0].x.value, 0);
     assert.strictEqual(value.transformComponents[0].x.type, 'px');

--- a/test/js/css-style-value.js
+++ b/test/js/css-style-value.js
@@ -24,7 +24,7 @@ suite('CSSStyleValue', function() {
 
   test('parse works for transform(translate)', function() {
     var value = CSSStyleValue.parse('transform', 'translate(10PX)');
-    assert.strictEqual(value.cssText, 'translate(10px)');
+    assert.strictEqual(value.cssText, 'translate(10PX)');
     assert.instanceOf(value.transformComponents[0], CSSTranslation);
     assert.strictEqual(value.transformComponents[0].x.value, 10);
     assert.strictEqual(value.transformComponents[0].x.type, 'px');
@@ -34,7 +34,7 @@ suite('CSSStyleValue', function() {
     assert.isNull(value.transformComponents[0].z);
 
     value = CSSStyleValue.parse('transform', 'translateZ(1px)');
-    assert.strictEqual(value.cssText, 'translatez(1px)');
+    assert.strictEqual(value.cssText, 'translateZ(1px)');
     assert.instanceOf(value.transformComponents[0], CSSTranslation);
     assert.strictEqual(value.transformComponents[0].x.value, 0);
     assert.strictEqual(value.transformComponents[0].x.type, 'px');

--- a/test/js/css-translation.js
+++ b/test/js/css-translation.js
@@ -86,14 +86,14 @@ suite('CSSTranslation', function() {
 
   test('Parsing valid basic strings results in CSSTranslation with correct values', function() {
     var values = [
-      {str: 'translate(10PX)', x: 10, y: 0, cssText: 'translate(10px)', remaining: ''},
-      {str: 'translate(10px) YAY', x: 10, y: 0, cssText: 'translate(10px)', remaining: 'YAY'},
-      {str: 'translate(-13px)', x: -13, y: 0, cssText: 'translate(-13px)', remaining: ''},
-      {str: 'TrAnSlAtE(14px)', x: 14, y: 0, cssText: 'translate(14px)', remaining: ''},
-      {str: 'translate(11px, 12px)', x: 11, y: 12, cssText: 'translate(11px, 12px)', remaining: ''},
-      {str: 'translate(11px, 12px)YAY', x: 11, y: 12, cssText: 'translate(11px, 12px)', remaining: 'YAY'},
-      {str: 'translate(-13px, -14px)', x: -13, y: -14, cssText: 'translate(-13px, -14px)', remaining: ''},
-      {str: 'TrAnSlAtE(15px, 16px)', x: 15, y: 16, cssText: 'translate(15px, 16px)', remaining: ''},
+      {str: 'translate(10PX)', x: 10, y: 0, remaining: ''},
+      {str: 'translate(10px) YAY', x: 10, y: 0, remaining: 'YAY'},
+      {str: 'translate(-13px)', x: -13, y: 0, remaining: ''},
+      {str: 'TrAnSlAtE(14px)', x: 14, y: 0, remaining: ''},
+      {str: 'translate(11px, 12px)', x: 11, y: 12, remaining: ''},
+      {str: 'translate(11px, 12px)YAY', x: 11, y: 12, remaining: 'YAY'},
+      {str: 'translate(-13px, -14px)', x: -13, y: -14, remaining: ''},
+      {str: 'TrAnSlAtE(15px, 16px)', x: 15, y: 16, remaining: ''},
     ];
     for (var i = 0; i < values.length; i++) {
       var parsed = typedOM.internal.parsing.consumeTranslation(values[i].str);
@@ -106,19 +106,19 @@ suite('CSSTranslation', function() {
       assert.strictEqual(parsed[0].x.type, 'px');
       assert.strictEqual(parsed[0].y.type, 'px');
       assert.strictEqual(parsed[0].z, null);
-      assert.strictEqual(parsed[0].cssText, values[i].cssText);
+      assert.strictEqual(parsed[0].cssText, values[i].str);
     }
   });
 
   test('Parsing valid 3d translation strings results in CSSTranslation with correct values', function() {
     var values = [
-      {str: 'translate3D(10PX, 11px, 12PX)', x: 10, y: 11, z: 12, cssText: 'translate3d(10px, 11px, 12px)', remaining: ''},
-      {str: 'translate3d(-13px, -14px, 15px)', x: -13, y: -14, z: 15, cssText: 'translate3d(-13px, -14px, 15px)', remaining: ''},
-      {str: 'TrAnSlAtE3d(16px, 17px, 18px)', x: 16, y: 17, z: 18, cssText: 'translate3d(16px, 17px, 18px)', remaining: ''},
-      {str: 'translate3d(16px, 17px, 18px)123', x: 16, y: 17, z: 18, cssText: 'translate3d(16px, 17px, 18px)', remaining: '123'},
-      {str: 'translatez(19PX)', x: 0, y: 0, z: 19, cssText: 'translatez(19px)', remaining: ''},
-      {str: 'translateZ(20px)', x: 0, y: 0, z: 20, cssText: 'translatez(20px)', remaining: ''},
-      {str: 'translateZ(20px) a1b2', x: 0, y: 0, z: 20, cssText: 'translatez(20px)', remaining: 'a1b2'},
+      {str: 'translate3D(10PX, 11px, 12PX)', x: 10, y: 11, z: 12, remaining: ''},
+      {str: 'translate3d(-13px, -14px, 15px)', x: -13, y: -14, z: 15, remaining: ''},
+      {str: 'TrAnSlAtE3d(16px, 17px, 18px)', x: 16, y: 17, z: 18, remaining: ''},
+      {str: 'translate3d(16px, 17px, 18px)123', x: 16, y: 17, z: 18, remaining: '123'},
+      {str: 'translatez(19PX)', x: 0, y: 0, z: 19, remaining: ''},
+      {str: 'translateZ(20px)', x: 0, y: 0, z: 20, remaining: ''},
+      {str: 'translateZ(20px) a1b2', x: 0, y: 0, z: 20, remaining: 'a1b2'},
     ];
     for (var i = 0; i < values.length; i++) {
       var parsed = typedOM.internal.parsing.consumeTranslation(values[i].str);
@@ -132,18 +132,18 @@ suite('CSSTranslation', function() {
       assert.strictEqual(parsed[0].x.type, 'px');
       assert.strictEqual(parsed[0].y.type, 'px');
       assert.strictEqual(parsed[0].z.type, 'px');
-      assert.strictEqual(parsed[0].cssText, values[i].cssText);
+      assert.strictEqual(parsed[0].cssText, values[i].str);
     }
   });
 
   test('Parsing valid X/Y-specific translation strings results in CSSTranslation with correct values', function() {
     var values = [
-      {str: 'translatex(19px)', x: 19, y: 0, cssText: 'translatex(19px)', remaining: ''},
-      {str: 'translateX(20PX)', x: 20, y: 0, cssText: 'translatex(20px)', remaining: ''},
-      {str: 'TranslateX(20px)bananas', x: 20, y: 0, cssText: 'translatex(20px)', remaining: 'bananas'},
-      {str: 'translatey(21px)', x: 0, y: 21, cssText: 'translatey(21px)', remaining: ''},
-      {str: 'translateY(22PX)', x: 0, y: 22, cssText: 'translatey(22px)', remaining: ''},
-      {str: 'Translatey(22PX) bananas', x: 0, y: 22, cssText: 'translatey(22px)', remaining: 'bananas'},
+      {str: 'translatex(19px)', x: 19, y: 0, remaining: ''},
+      {str: 'translateX(20PX)', x: 20, y: 0, remaining: ''},
+      {str: 'TranslateX(20px)bananas', x: 20, y: 0, remaining: 'bananas'},
+      {str: 'translatey(21px)', x: 0, y: 21, remaining: ''},
+      {str: 'translateY(22PX)', x: 0, y: 22, remaining: ''},
+      {str: 'Translatey(22PX) bananas', x: 0, y: 22, remaining: 'bananas'},
     ];
     for (var i = 0; i < values.length; i++) {
       var parsed = typedOM.internal.parsing.consumeTranslation(values[i].str);
@@ -156,7 +156,7 @@ suite('CSSTranslation', function() {
       assert.strictEqual(parsed[0].x.type, 'px');
       assert.strictEqual(parsed[0].y.type, 'px');
       assert.strictEqual(parsed[0].z, null);
-      assert.strictEqual(parsed[0].cssText, values[i].cssText);
+      assert.strictEqual(parsed[0].cssText, values[i].str);
     }
   });
 

--- a/test/js/css-translation.js
+++ b/test/js/css-translation.js
@@ -86,14 +86,14 @@ suite('CSSTranslation', function() {
 
   test('Parsing valid basic strings results in CSSTranslation with correct values', function() {
     var values = [
-      {str: 'translate(10PX)', x: 10, y: 0, remaining: ''},
-      {str: 'translate(10px) YAY', x: 10, y: 0, remaining: 'YAY'},
-      {str: 'translate(-13px)', x: -13, y: 0, remaining: ''},
-      {str: 'TrAnSlAtE(14px)', x: 14, y: 0, remaining: ''},
-      {str: 'translate(11px, 12px)', x: 11, y: 12, remaining: ''},
-      {str: 'translate(11px, 12px)YAY', x: 11, y: 12, remaining: 'YAY'},
-      {str: 'translate(-13px, -14px)', x: -13, y: -14, remaining: ''},
-      {str: 'TrAnSlAtE(15px, 16px)', x: 15, y: 16, remaining: ''},
+      {str: 'translate(10PX)', x: 10, y: 0, cssText: 'translate(10px)', remaining: ''},
+      {str: 'translate(10px) YAY', x: 10, y: 0, cssText: 'translate(10px)', remaining: 'YAY'},
+      {str: 'translate(-13px)', x: -13, y: 0, cssText: 'translate(-13px)', remaining: ''},
+      {str: 'TrAnSlAtE(14px)', x: 14, y: 0, cssText: 'translate(14px)', remaining: ''},
+      {str: 'translate(11px, 12px)', x: 11, y: 12, cssText: 'translate(11px, 12px)', remaining: ''},
+      {str: 'translate(11px, 12px)YAY', x: 11, y: 12, cssText: 'translate(11px, 12px)', remaining: 'YAY'},
+      {str: 'translate(-13px, -14px)', x: -13, y: -14, cssText: 'translate(-13px, -14px)', remaining: ''},
+      {str: 'TrAnSlAtE(15px, 16px)', x: 15, y: 16, cssText: 'translate(15px, 16px)', remaining: ''},
     ];
     for (var i = 0; i < values.length; i++) {
       var parsed = typedOM.internal.parsing.consumeTranslation(values[i].str);
@@ -106,18 +106,19 @@ suite('CSSTranslation', function() {
       assert.strictEqual(parsed[0].x.type, 'px');
       assert.strictEqual(parsed[0].y.type, 'px');
       assert.strictEqual(parsed[0].z, null);
+      assert.strictEqual(parsed[0].cssText, values[i].cssText);
     }
   });
 
   test('Parsing valid 3d translation strings results in CSSTranslation with correct values', function() {
     var values = [
-      {str: 'translate3D(10PX, 11px, 12PX)', x: 10, y: 11, z: 12, remaining: ''},
-      {str: 'translate3d(-13px, -14px, 15px)', x: -13, y: -14, z: 15, remaining: ''},
-      {str: 'TrAnSlAtE3d(16px, 17px, 18px)', x: 16, y: 17, z: 18, remaining: ''},
-      {str: 'translate3d(16px, 17px, 18px)123', x: 16, y: 17, z: 18, remaining: '123'},
-      {str: 'translatez(19PX)', x: 0, y: 0, z: 19, remaining: ''},
-      {str: 'translateZ(20px)', x: 0, y: 0, z: 20, remaining: ''},
-      {str: 'translateZ(20px) a1b2', x: 0, y: 0, z: 20, remaining: 'a1b2'},
+      {str: 'translate3D(10PX, 11px, 12PX)', x: 10, y: 11, z: 12, cssText: 'translate3d(10px, 11px, 12px)', remaining: ''},
+      {str: 'translate3d(-13px, -14px, 15px)', x: -13, y: -14, z: 15, cssText: 'translate3d(-13px, -14px, 15px)', remaining: ''},
+      {str: 'TrAnSlAtE3d(16px, 17px, 18px)', x: 16, y: 17, z: 18, cssText: 'translate3d(16px, 17px, 18px)', remaining: ''},
+      {str: 'translate3d(16px, 17px, 18px)123', x: 16, y: 17, z: 18, cssText: 'translate3d(16px, 17px, 18px)', remaining: '123'},
+      {str: 'translatez(19PX)', x: 0, y: 0, z: 19, cssText: 'translatez(19px)', remaining: ''},
+      {str: 'translateZ(20px)', x: 0, y: 0, z: 20, cssText: 'translatez(20px)', remaining: ''},
+      {str: 'translateZ(20px) a1b2', x: 0, y: 0, z: 20, cssText: 'translatez(20px)', remaining: 'a1b2'},
     ];
     for (var i = 0; i < values.length; i++) {
       var parsed = typedOM.internal.parsing.consumeTranslation(values[i].str);
@@ -131,17 +132,18 @@ suite('CSSTranslation', function() {
       assert.strictEqual(parsed[0].x.type, 'px');
       assert.strictEqual(parsed[0].y.type, 'px');
       assert.strictEqual(parsed[0].z.type, 'px');
+      assert.strictEqual(parsed[0].cssText, values[i].cssText);
     }
   });
 
   test('Parsing valid X/Y-specific translation strings results in CSSTranslation with correct values', function() {
     var values = [
-      {str: 'translatex(19px)', x: 19, y: 0, remaining: ''},
-      {str: 'translateX(20PX)', x: 20, y: 0, remaining: ''},
-      {str: 'TranslateX(20px)bananas', x: 20, y: 0, remaining: 'bananas'},
-      {str: 'translatey(21px)', x: 0, y: 21, remaining: ''},
-      {str: 'translateY(22PX)', x: 0, y: 22, remaining: ''},
-      {str: 'Translatey(22PX) bananas', x: 0, y: 22, remaining: 'bananas'},
+      {str: 'translatex(19px)', x: 19, y: 0, cssText: 'translatex(19px)', remaining: ''},
+      {str: 'translateX(20PX)', x: 20, y: 0, cssText: 'translatex(20px)', remaining: ''},
+      {str: 'TranslateX(20px)bananas', x: 20, y: 0, cssText: 'translatex(20px)', remaining: 'bananas'},
+      {str: 'translatey(21px)', x: 0, y: 21, cssText: 'translatey(21px)', remaining: ''},
+      {str: 'translateY(22PX)', x: 0, y: 22, cssText: 'translatey(22px)', remaining: ''},
+      {str: 'Translatey(22PX) bananas', x: 0, y: 22, cssText: 'translatey(22px)', remaining: 'bananas'},
     ];
     for (var i = 0; i < values.length; i++) {
       var parsed = typedOM.internal.parsing.consumeTranslation(values[i].str);
@@ -154,6 +156,7 @@ suite('CSSTranslation', function() {
       assert.strictEqual(parsed[0].x.type, 'px');
       assert.strictEqual(parsed[0].y.type, 'px');
       assert.strictEqual(parsed[0].z, null);
+      assert.strictEqual(parsed[0].cssText, values[i].cssText);
     }
   });
 


### PR DESCRIPTION
Make CSSTranslation.cssText reflect input text for parsed values & make it lazy.

Makes it consistent with https://github.com/css-typed-om/typed-om/pull/130/files (rotate and skew).

Other types will follow in separate PRs.
