### PR TITLE
Update CSSScale.cssText to new style

### DIFF
--- a/src/css-scale.js
+++ b/src/css-scale.js
@@ -54,13 +54,7 @@
 
     this.x = x;
     this.y = y;
-    if (typeof z == 'number') {
-      this.z = z;
-      this._inputType = '3';
-    } else {
-      this.z = null;
-      this._inputType = '2';
-    }
+    this.z = (typeof z == 'number') ? z : null;
 
     this.matrix = computeMatrix(this);
     this.is2D = this.matrix.is2D;
@@ -98,7 +92,7 @@
       return null;
     }
     var result = [new CSSScale(numbers[0], numbers[1], numbers[2]), remaining];
-    result[0].result[0]._cssText = string;;
+    result[0]._cssText = string;;
     return result;
   }
 

--- a/src/css-scale.js
+++ b/src/css-scale.js
@@ -29,22 +29,15 @@
   };
 
   function generateCssString(cssScale) {
-    switch (cssScale._inputType) {
-      case '1':
-        return 'scale(' + cssScale.x + ')';
-      case '2':
-        return 'scale(' + cssScale.x + ', ' + cssScale.y + ')';
-      case '3':
-        return 'scale3d('
-          + cssScale.x + ', '
-          + cssScale.y + ', '
-          + cssScale.z + ')';
-      case 'x':
-        return 'scalex(' + cssScale.x + ')';
-      case 'y':
-        return 'scaley(' + cssScale.y + ')';
-      case 'z':
-        return 'scalez(' + cssScale.z + ')';
+    if(cssScale.is2D) {
+      return 'scale('
+        + cssScale.x + ', '
+        + cssScale.y + ')';
+    } else {
+      return 'scale3d('
+        + cssScale.x + ', '
+        + cssScale.y + ', '
+        + cssScale.z + ')';
     }
   };
 
@@ -71,6 +64,7 @@
 
     this.matrix = computeMatrix(this);
     this.is2D = this.matrix.is2D;
+
     Object.defineProperty(this, 'cssText', {
       get: function() {
         if (!this._cssText) {
@@ -82,6 +76,64 @@
     });
   }
   internal.inherit(CSSScale, internal.CSSTransformComponent);
+
+  // These functions (cssScaleFromScale*) are for making CSSScales from parsed CSS
+  // Strings. These are needed for setting the cssText.
+  function cssScaleFromScale(numbers, string, remaining) {
+    if (numbers.length == 1) {
+      var result = [new CSSScale(numbers[0], numbers[0]), remaining];
+      result[0]._cssText = string;
+      return result;
+    }
+    if (numbers.length == 2) {
+      var result = [new CSSScale(numbers[0], numbers[1]), remaining];
+      result[0]._cssText = string;
+      return result;
+    }
+    return null;
+  }
+
+  function cssScaleFromScale3d(numbers, string, remaining) {
+    if (numbers.length != 3) {
+      return null;
+    }
+    var result = [new CSSScale(numbers[0], numbers[1], numbers[2]), remaining];
+    result[0].result[0]._cssText = string;;
+    return result;
+  }
+
+  function cssScaleFromScaleX(numbers, string, remaining) {
+    if (numbers.length != 1) {
+      return null;
+    }
+    var result = [new CSSScale(numbers[0], 1), remaining];
+    result[0]._cssText = string;
+    return result;
+  }
+
+  function cssScaleFromScaleY(numbers, string, remaining) {
+    if (numbers.length != 1) {
+      return null;
+    }
+      var result = [new CSSScale(1, numbers[0]), remaining];
+      result[0]._cssText = string;
+      return result;
+  }
+
+  function cssScaleFromScaleZ(numbers, string, remaining) {
+    if (numbers.length != 1) {
+      return null;
+    }
+      var result = [new CSSScale(1, 1, numbers[0]), remaining];
+      result[0]._cssText = string;
+      return result;
+  }
+
+  internal.cssScaleFromScale = cssScaleFromScale;
+  internal.cssScaleFromScale3d = cssScaleFromScale3d;
+  internal.cssScaleFromScaleX = cssScaleFromScaleX;
+  internal.cssScaleFromScaleY = cssScaleFromScaleY;
+  internal.cssScaleFromScaleZ = cssScaleFromScaleZ;
 
   scope.CSSScale = CSSScale;
 

--- a/src/css-scale.js
+++ b/src/css-scale.js
@@ -29,13 +29,23 @@
   };
 
   function generateCssString(cssScale) {
-    var cssText;
-    if (cssScale.is2D) {
-      cssText = 'scale(' + cssScale.x + ', ' + cssScale.y + ')';
-    } else {
-      cssText = 'scale3d(' + cssScale.x + ', ' + cssScale.y + ', ' + cssScale.z + ')';
+    switch (cssScale._inputType) {
+      case '1':
+        return 'scale(' + cssScale.x + ')';
+      case '2':
+        return 'scale(' + cssScale.x + ', ' + cssScale.y + ')';
+      case '3':
+        return 'scale3d('
+          + cssScale.x + ', '
+          + cssScale.y + ', '
+          + cssScale.z + ')';
+      case 'x':
+        return 'scalex(' + cssScale.x + ')';
+      case 'y':
+        return 'scaley(' + cssScale.y + ')';
+      case 'z':
+        return 'scalez(' + cssScale.z + ')';
     }
-    return cssText;
   };
 
   function CSSScale(x, y, z) {
@@ -51,11 +61,25 @@
 
     this.x = x;
     this.y = y;
-    this.z = (typeof z == 'number') ? z : null;
+    if (typeof z == 'number') {
+      this.z = z;
+      this._inputType = '3';
+    } else {
+      this.z = null;
+      this._inputType = '2';
+    }
 
     this.matrix = computeMatrix(this);
     this.is2D = this.matrix.is2D;
-    this.cssText = generateCssString(this);
+    Object.defineProperty(this, 'cssText', {
+      get: function() {
+        if (!this._cssText) {
+          this._cssText = generateCssString(this);
+        }
+        return this._cssText;
+      },
+      set: function(newCssText) {}
+    });
   }
   internal.inherit(CSSScale, internal.CSSTransformComponent);
 

--- a/src/parsing/css-scale-parsing.js
+++ b/src/parsing/css-scale-parsing.js
@@ -33,7 +33,7 @@
 
     switch (type) {
       case '3d':
-        return internal.cssScaleFromScale3D(numbers, string, remaining);
+        return internal.cssScaleFromScale3d(numbers, string, remaining);
       case 'x':
         return internal.cssScaleFromScaleX(numbers, string, remaining);
       case 'y':

--- a/src/parsing/css-scale-parsing.js
+++ b/src/parsing/css-scale-parsing.js
@@ -19,7 +19,9 @@
     if (numbers.length != 3) {
       return null;
     }
-    return [new CSSScale(numbers[0], numbers[1], numbers[2]), remaining];
+    var result = [new CSSScale(numbers[0], numbers[1], numbers[2]), remaining];
+    result[0].inputType = '3';
+    return result;
   }
 
   function scaleXYorZ(xyOrZ, numbers, remaining) {
@@ -28,11 +30,17 @@
     }
     switch (xyOrZ) {
       case 'x':
-        return [new CSSScale(numbers[0], 1), remaining];
+        var result = [new CSSScale(numbers[0], 1), remaining];
+        result[0]._inputType = 'x';
+        return result;
       case 'y':
-        return [new CSSScale(1, numbers[0]), remaining];
+        var result = [new CSSScale(1, numbers[0]), remaining];
+        result[0]._inputType = 'y';
+        return result;
       case 'z':
-        return [new CSSScale(1, 1, numbers[0]), remaining];
+        var result = [new CSSScale(1, 1, numbers[0]), remaining];
+        result[0]._inputType = 'z';
+        return result;
     }
     return null;
   }
@@ -64,10 +72,14 @@
 
     // Only scale(s) and scale(x, y) remain.
     if (numbers.length == 1) {
-      return [new CSSScale(numbers[0], numbers[0]), remaining];
+      var result = [new CSSScale(numbers[0], numbers[0]), remaining];
+      result[0]._inputType = '1';
+      return result;
     }
     if (numbers.length == 2) {
-      return [new CSSScale(numbers[0], numbers[1]), remaining];
+      var result = [new CSSScale(numbers[0], numbers[1]), remaining];
+      result[0]._inputType = '2';
+      return result;
     }
     return null;
   }

--- a/src/parsing/css-scale-parsing.js
+++ b/src/parsing/css-scale-parsing.js
@@ -15,36 +15,6 @@
 (function(internal) {
   var parsing = internal.parsing;
 
-  function scale3d(numbers, remaining) {
-    if (numbers.length != 3) {
-      return null;
-    }
-    var result = [new CSSScale(numbers[0], numbers[1], numbers[2]), remaining];
-    result[0].inputType = '3';
-    return result;
-  }
-
-  function scaleXYorZ(xyOrZ, numbers, remaining) {
-    if (numbers.length != 1) {
-      return null;
-    }
-    switch (xyOrZ) {
-      case 'x':
-        var result = [new CSSScale(numbers[0], 1), remaining];
-        result[0]._inputType = 'x';
-        return result;
-      case 'y':
-        var result = [new CSSScale(1, numbers[0]), remaining];
-        result[0]._inputType = 'y';
-        return result;
-      case 'z':
-        var result = [new CSSScale(1, 1, numbers[0]), remaining];
-        result[0]._inputType = 'z';
-        return result;
-    }
-    return null;
-  }
-
   function consumeScale(string) {
     var params = parsing.consumeList([
         parsing.ignore(parsing.consumeToken.bind(null, /^scale/i)),
@@ -63,25 +33,17 @@
 
     switch (type) {
       case '3d':
-        return scale3d(numbers, remaining);
+        return internal.cssScaleFromScale3D(numbers, string, remaining);
       case 'x':
+        return internal.cssScaleFromScaleX(numbers, string, remaining);
       case 'y':
+        return internal.cssScaleFromScaleY(numbers, string, remaining);
       case 'z':
-        return scaleXYorZ(type, numbers, remaining);
+        return internal.cssScaleFromScaleZ(numbers, string, remaining);
     }
 
     // Only scale(s) and scale(x, y) remain.
-    if (numbers.length == 1) {
-      var result = [new CSSScale(numbers[0], numbers[0]), remaining];
-      result[0]._inputType = '1';
-      return result;
-    }
-    if (numbers.length == 2) {
-      var result = [new CSSScale(numbers[0], numbers[1]), remaining];
-      result[0]._inputType = '2';
-      return result;
-    }
-    return null;
+    return internal.cssScaleFromScale(numbers, string, remaining);
   }
 
   internal.parsing.consumeScale = consumeScale;

--- a/test/js/css-scale.js
+++ b/test/js/css-scale.js
@@ -44,19 +44,19 @@ suite('CSSScale', function() {
 
   test('Parsing valid strings results in CSSScale with correct values', function() {
     var values = [
-      {str: 'scale(1.001)', x: 1.001, y: 1.001, z: null, remaining: ''},
-      {str: 'ScAle(2)', x: 2, y: 2, z: null, remaining: ''},
-      {str: 'scale(2, 3)', x: 2, y: 3, z: null, remaining: ''},
-      {str: 'SCALE(2.2, 3)', x: 2.2, y: 3, z: null, remaining: ''},
-      {str: 'scalex(4)', x: 4, y: 1, z: null, remaining: ''},
-      {str: 'scaleX(5)bananas', x: 5, y: 1, z: null, remaining: 'bananas'},
-      {str: 'scaley(6)', x: 1, y: 6, z: null, remaining: ''},
-      {str: 'ScaleY(7) bananas', x: 1, y: 7, z: null, remaining: 'bananas'},
-      {str: 'scalez(8) ', x: 1, y: 1, z: 8, remaining: ''},
-      {str: 'ScaleZ(9) abc', x: 1, y: 1, z: 9, remaining: 'abc'},
-      {str: 'scale3d(10, 11, 12) abc', x: 10, y: 11, z: 12, remaining: 'abc'},
-      {str: 'Scale3D(13, 14, 15) abc', x: 13, y: 14, z: 15, remaining: 'abc'},
-      {str: 'Scale3D(0.8, 2, 0.2)', x: 0.8, y: 2, z: 0.2, remaining: ''},
+      {str: 'scale(1.001)', x: 1.001, y: 1.001, z: null, cssText: 'scale(1.001)', remaining: ''},
+      {str: 'ScAle(2)', x: 2, y: 2, z: null, cssText: 'scale(2)', remaining: ''},
+      {str: 'scale(2, 3)', x: 2, y: 3, z: null, cssText: 'scale(2, 3)', remaining: ''},
+      {str: 'SCALE(2.2, 3)', x: 2.2, y: 3, z: null, cssText: 'scale(2.2, 3)', remaining: ''},
+      {str: 'scalex(4)', x: 4, y: 1, z: null, cssText: 'scalex(4)', remaining: ''},
+      {str: 'scaleX(5)bananas', x: 5, y: 1, z: null, cssText: 'scalex(5)', remaining: 'bananas'},
+      {str: 'scaley(6)', x: 1, y: 6, z: null, cssText: 'scaley(6)', remaining: ''},
+      {str: 'ScaleY(7) bananas', x: 1, y: 7, z: null, cssText: 'scaley(7)', remaining: 'bananas'},
+      {str: 'scalez(8) ', x: 1, y: 1, z: 8, cssText: 'scalez(8)', remaining: ''},
+      {str: 'ScaleZ(9) abc', x: 1, y: 1, z: 9, cssText: 'scalez(9)', remaining: 'abc'},
+      {str: 'scale3d(10, 11, 12) abc', x: 10, y: 11, z: 12, cssText: 'scale3d(10, 11, 12)', remaining: 'abc'},
+      {str: 'Scale3D(13, 14, 15) abc', x: 13, y: 14, z: 15, cssText: 'scale3d(13, 14, 15)', remaining: 'abc'},
+      {str: 'Scale3D(0.8, 2, 0.2)', x: 0.8, y: 2, z: 0.2, cssText: 'scale3d(0.8, 2, 0.2)', remaining: ''},
     ];
     for (var i = 0; i < values.length; i++) {
       var parsed = typedOM.internal.parsing.consumeScale(values[i].str);
@@ -65,6 +65,7 @@ suite('CSSScale', function() {
       assert.strictEqual(parsed[0].x, values[i].x);
       assert.strictEqual(parsed[0].y, values[i].y);
       assert.strictEqual(parsed[0].z, values[i].z);
+      assert.strictEqual(parsed[0].cssText, values[i].cssText);
     }
   });
 

--- a/test/js/css-scale.js
+++ b/test/js/css-scale.js
@@ -44,19 +44,19 @@ suite('CSSScale', function() {
 
   test('Parsing valid strings results in CSSScale with correct values', function() {
     var values = [
-      {str: 'scale(1.001)', x: 1.001, y: 1.001, z: null, cssText: 'scale(1.001)', remaining: ''},
-      {str: 'ScAle(2)', x: 2, y: 2, z: null, cssText: 'scale(2)', remaining: ''},
-      {str: 'scale(2, 3)', x: 2, y: 3, z: null, cssText: 'scale(2, 3)', remaining: ''},
-      {str: 'SCALE(2.2, 3)', x: 2.2, y: 3, z: null, cssText: 'scale(2.2, 3)', remaining: ''},
-      {str: 'scalex(4)', x: 4, y: 1, z: null, cssText: 'scalex(4)', remaining: ''},
-      {str: 'scaleX(5)bananas', x: 5, y: 1, z: null, cssText: 'scalex(5)', remaining: 'bananas'},
-      {str: 'scaley(6)', x: 1, y: 6, z: null, cssText: 'scaley(6)', remaining: ''},
-      {str: 'ScaleY(7) bananas', x: 1, y: 7, z: null, cssText: 'scaley(7)', remaining: 'bananas'},
-      {str: 'scalez(8) ', x: 1, y: 1, z: 8, cssText: 'scalez(8)', remaining: ''},
-      {str: 'ScaleZ(9) abc', x: 1, y: 1, z: 9, cssText: 'scalez(9)', remaining: 'abc'},
-      {str: 'scale3d(10, 11, 12) abc', x: 10, y: 11, z: 12, cssText: 'scale3d(10, 11, 12)', remaining: 'abc'},
-      {str: 'Scale3D(13, 14, 15) abc', x: 13, y: 14, z: 15, cssText: 'scale3d(13, 14, 15)', remaining: 'abc'},
-      {str: 'Scale3D(0.8, 2, 0.2)', x: 0.8, y: 2, z: 0.2, cssText: 'scale3d(0.8, 2, 0.2)', remaining: ''},
+      {str: 'scale(1.001)', x: 1.001, y: 1.001, z: null, remaining: ''},
+      {str: 'ScAle(2)', x: 2, y: 2, z: null, remaining: ''},
+      {str: 'scale(2, 3)', x: 2, y: 3, z: null, remaining: ''},
+      {str: 'SCALE(2.2, 3)', x: 2.2, y: 3, z: null, remaining: ''},
+      {str: 'scalex(4)', x: 4, y: 1, z: null, remaining: ''},
+      {str: 'scaleX(5)bananas', x: 5, y: 1, z: null, remaining: 'bananas'},
+      {str: 'scaley(6)', x: 1, y: 6, z: null, remaining: ''},
+      {str: 'ScaleY(7) bananas', x: 1, y: 7, z: null, remaining: 'bananas'},
+      {str: 'scalez(8) ', x: 1, y: 1, z: 8, remaining: ''},
+      {str: 'ScaleZ(9) abc', x: 1, y: 1, z: 9, remaining: 'abc'},
+      {str: 'scale3d(10, 11, 12) abc', x: 10, y: 11, z: 12, remaining: 'abc'},
+      {str: 'Scale3D(13, 14, 15) abc', x: 13, y: 14, z: 15, remaining: 'abc'},
+      {str: 'Scale3D(0.8, 2, 0.2)', x: 0.8, y: 2, z: 0.2, remaining: ''},
     ];
     for (var i = 0; i < values.length; i++) {
       var parsed = typedOM.internal.parsing.consumeScale(values[i].str);
@@ -65,7 +65,7 @@ suite('CSSScale', function() {
       assert.strictEqual(parsed[0].x, values[i].x);
       assert.strictEqual(parsed[0].y, values[i].y);
       assert.strictEqual(parsed[0].z, values[i].z);
-      assert.strictEqual(parsed[0].cssText, values[i].cssText);
+      assert.strictEqual(parsed[0].cssText, values[i].str);
     }
   });
 

--- a/test/js/css-style-value.js
+++ b/test/js/css-style-value.js
@@ -82,7 +82,6 @@ suite('CSSStyleValue', function() {
 
   test('parse works for transform(scale)', function() {
     var value = CSSStyleValue.parse('transform', 'scale(2)');
-    // TODO: Change cssText for CSSScale so that it reflects parsed string.
     assert.strictEqual(value.cssText, 'scale(2)');
     assert.instanceOf(value.transformComponents[0], CSSScale);
     assert.strictEqual(value.transformComponents[0].x, 2);

--- a/test/js/css-style-value.js
+++ b/test/js/css-style-value.js
@@ -83,7 +83,7 @@ suite('CSSStyleValue', function() {
   test('parse works for transform(scale)', function() {
     var value = CSSStyleValue.parse('transform', 'scale(2)');
     // TODO: Change cssText for CSSScale so that it reflects parsed string.
-    assert.strictEqual(value.cssText, 'scale(2, 2)');
+    assert.strictEqual(value.cssText, 'scale(2)');
     assert.instanceOf(value.transformComponents[0], CSSScale);
     assert.strictEqual(value.transformComponents[0].x, 2);
     assert.strictEqual(value.transformComponents[0].y, 2);
@@ -91,14 +91,14 @@ suite('CSSStyleValue', function() {
     assert.isNull(value.transformComponents[0].z);
 
     value = CSSStyleValue.parse('transform', 'scaley(2)');
-    assert.strictEqual(value.cssText, 'scale(1, 2)');
+    assert.strictEqual(value.cssText, 'scaley(2)');
     assert.instanceOf(value.transformComponents[0], CSSScale);
     assert.strictEqual(value.transformComponents[0].x, 1);
     assert.strictEqual(value.transformComponents[0].y, 2);
     assert.isNull(value.transformComponents[0].z);
 
     value = CSSStyleValue.parse('transform', 'scalez(2)');
-    assert.strictEqual(value.cssText, 'scale3d(1, 1, 2)');
+    assert.strictEqual(value.cssText, 'scalez(2)');
     assert.instanceOf(value.transformComponents[0], CSSScale);
     assert.strictEqual(value.transformComponents[0].x, 1);
     assert.strictEqual(value.transformComponents[0].y, 1);


### PR DESCRIPTION
Make CSSScale.cssText reflect input text for parsed values & make it lazy.

Makes it consistent with https://github.com/css-typed-om/typed-om/pull/130/files (rotate and skew) and https://github.com/css-typed-om/typed-om/pull/141 (translate).

Other types will follow in separate PRs.
