### PR TITLE
CSSVariableReferenceValue's fallback can be undefined

### DIFF
--- a/src/css-variable-reference-value.js
+++ b/src/css-variable-reference-value.js
@@ -7,7 +7,7 @@
     if (typeof variable != 'string') {
       throw new TypeError('Variable of CSSVariableReferenceValue must be a string');
     }
-    if (!(fallback instanceof CSSTokenStreamValue)) {
+    if ((fallback !== undefined) && !(fallback instanceof CSSTokenStreamValue)) {
       throw new TypeError('Fallback of CSSVariableReferenceValue must be a CSSTokenStreamValue');
     }
     this.variable = variable;
@@ -15,5 +15,5 @@
   }
 
   scope.CSSVariableReferenceValue = CSSVariableReferenceValue;
-    
+
 })(typedOM.internal, window);

--- a/test/js/css-variable-reference-value.js
+++ b/test/js/css-variable-reference-value.js
@@ -1,5 +1,5 @@
 suite('CSSVariableReferenceValue', function() {
-  test("The new CSSVariableReferenceValue attributes are correct", function() {
+  test('The new CSSVariableReferenceValue attributes are correct', function() {
     var expectedVariable = 'anything';
     var expectedFallback = new CSSTokenStreamValue(["123"]);
     var referenceValue = new CSSVariableReferenceValue(expectedVariable, expectedFallback);
@@ -18,4 +18,8 @@ suite('CSSVariableReferenceValue', function() {
     assert.throw(function() { new CSSVariableReferenceValue(["1"], 1234); }, TypeError, 'Variable of CSSVariableReferenceValue must be a string');
     assert.throw(function() { new CSSVariableReferenceValue("123", 1234); }, TypeError, 'Fallback of CSSVariableReferenceValue must be a CSSTokenStreamValue');
   });
+
+  test('CSSVariableReferenceValue can have undefined fallback', function() {
+    assert.doesNotThrow(function() { new CSSVariableReferenceValue("--var", undefined); });
+  })
 });


### PR DESCRIPTION
In this example https://drafts.css-houdini.org/css-typed-om/#cssunparsedvalue the fallback can be undefined.
