### PR TITLE
adds empty CSS.escape polyfill, needed ES6 polyfills

### DIFF
--- a/src/polyfills.js
+++ b/src/polyfills.js
@@ -1,0 +1,51 @@
+// Copyright 2016 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//     You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//     See the License for the specific language governing permissions and
+// limitations under the License.
+
+(function(internal, scope) {
+  // Adds non-CSS related ES6 polyfills needed for Typed OM.
+  if (!Number.isFinite) {
+    Number.isFinite = function(v) { return typeof v === 'number' && isFinite(v); };
+  }
+  if (!Number.isInteger) {
+    Number.isInteger = function(v) {
+      return typeof v === 'number' && isFinite(v) && Math.floor(v) === v;
+    };
+  }
+  if (!Number.isNaN) {
+    Number.isNaN = function(v) { return typeof v === 'number' && isNaN(v); };
+  }
+  if (!String.prototype.startsWith) {
+    String.prototype.startsWith = function(v) { return this.substr(0, v.length) === v; };
+  }
+
+  /**
+   * Escapes the passed string for use as part of a CSS selector. This is a polyfill for browsers
+   * that do not impement this feature (As of 2016-09, supported only in Chrome and Firefox).
+   * @param {string|number} str to escape
+   * @return {string} escaped string
+   */
+  function escape(str) {
+    // TODO(samthor): Implement escape().
+    return '' + str;
+  }
+
+  if (!scope.CSS) {
+    scope.CSS = {};
+  }
+  if (!scope.CSS.escape) {
+    scope.CSS.escape = escape;
+  }
+
+  internal.escape = escape;
+})(typedOM.internal, window);

--- a/src/style-property-map-readonly.js
+++ b/src/style-property-map-readonly.js
@@ -35,6 +35,9 @@
 
     if (internal.propertyDictionary().isSupportedProperty(property)) {
       var result = CSSStyleValue.parse(property, propertyString);
+      if (result == null) {
+        return null;
+      }
       return Array.isArray(result) ? result : [result];
     }
     return [new internal.CSSStyleValue(propertyString)];

--- a/target-config.js
+++ b/target-config.js
@@ -20,6 +20,8 @@
 
   // These should be alphabetical order as much as possible.
   var typedOMSrc = [
+      // Polyfills for missing browser features
+      'src/polyfills.js',
       // Utility functions
       'src/util.js',
       // CSSTransformComponent and subclasses
@@ -99,6 +101,7 @@
       'test/js/css-variable-reference-value.js',
       'test/js/computed-style-property-map.js',
       'test/js/dom-matrix-readonly.js',
+      'test/js/escape.js',
       'test/js/inline-style-property-map.js',
       'test/js/parsing.js',
       'test/js/property-dictionary.js',

--- a/test/js/escape.js
+++ b/test/js/escape.js
@@ -1,0 +1,21 @@
+// Copyright 2016 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//     You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//     See the License for the specific language governing permissions and
+// limitations under the License.
+
+suite('CSS.escape polyfill', function() {
+  var escape = typedOM.internal.escape;
+
+  test('Test simple escapes', function() {
+    assert.equal('test', escape('test'));
+  });
+});


### PR DESCRIPTION
This allows `npm test` to run, and most tests now pass.

Depending on choice of ES6 transpiler, and the options we use, the `Number` and `String.prototype` polyfills might eventually come for free.
