### PR TITLE
Test cleanup

### DIFF
--- a/test/js/computed-style-property-map.js
+++ b/test/js/computed-style-property-map.js
@@ -22,11 +22,12 @@ suite('Computed StylePropertyMap', function() {
     document.body.removeChild(this.element);
   });
 
+  var lemonNotSupportedErr = /^lemon is not a supported CSS property$/;
+
   test('get method throws a TypeError if the property is not supported', function() {
     var computedStyleMap = getComputedStyleMap(this.element);
 
-    assert.throw(function() {computedStyleMap.get('lemon')}, TypeError,
-      'lemon is not a supported CSS property');
+    assert.throws(function() {computedStyleMap.get('lemon')}, TypeError, lemonNotSupportedErr);
   });
 
 
@@ -87,8 +88,7 @@ suite('Computed StylePropertyMap', function() {
   test('getAll method throws a TypeError if the property is not supported', function() {
     var computedStyleMap = getComputedStyleMap(this.element);
 
-    assert.throw(function() {computedStyleMap.getAll('lemon')}, TypeError,
-      'lemon is not a supported CSS property');
+    assert.throws(function() {computedStyleMap.getAll('lemon')}, TypeError, lemonNotSupportedErr);
   });
 
   test('getting an unsupported but valid property returns a base CSSStyleValue', function() {

--- a/test/js/css-angle-value.js
+++ b/test/js/css-angle-value.js
@@ -39,21 +39,24 @@ test('CSSAngleValue constructor works for valid arguments', function() {
 });
 
 test('Wrong number of arguments throws', function() {
-  assert.throw(function() { new CSSAngleValue(); }, TypeError, 'Must specify an angle and a unit');
-  assert.throw(function() { new CSSAngleValue(5); }, TypeError, 'Must specify an angle and a unit');
-  assert.throw(function() { new CSSAngleValue(5, 5, 5); }, TypeError, 'Must specify an angle and a unit');
+  var specifyErr = /^Must specify an angle and a unit$/;
+  assert.throws(function() { new CSSAngleValue(); }, TypeError, specifyErr);
+  assert.throws(function() { new CSSAngleValue(5); }, TypeError, specifyErr);
+  assert.throws(function() { new CSSAngleValue(5, 5, 5); }, TypeError, specifyErr);
 });
 
 test('Value not a number throws', function() {
-  assert.throw(function() { new CSSAngleValue('foo', 'deg'); }, TypeError, 'Value must be a number');
-  assert.throw(function() { new CSSAngleValue({}, 'deg'); }, TypeError, 'Value must be a number');
-  assert.throw(function() { new CSSAngleValue(undefined, 'deg'); }, TypeError, 'Value must be a number');
+  var numberErr = /^Value must be a number$/;
+  assert.throws(function() { new CSSAngleValue('foo', 'deg'); }, TypeError, numberErr);
+  assert.throws(function() { new CSSAngleValue({}, 'deg'); }, TypeError, numberErr);
+  assert.throws(function() { new CSSAngleValue(undefined, 'deg'); }, TypeError, numberErr);
 });
 
 test('Invalid unit throws', function() {
-  assert.throw(function() { new CSSAngleValue(5, 'asdfa'); }, TypeError, 'Invalid unit type');
-  assert.throw(function() { new CSSAngleValue(5, {}); }, TypeError, 'Invalid unit type');
-  assert.throw(function() { new CSSAngleValue(5, 5); }, TypeError, 'Invalid unit type');
+  var unitErr = /^Invalid unit type$/;
+  assert.throws(function() { new CSSAngleValue(5, 'asdfa'); }, TypeError, unitErr);
+  assert.throws(function() { new CSSAngleValue(5, {}); }, TypeError, unitErr);
+  assert.throws(function() { new CSSAngleValue(5, 5); }, TypeError, unitErr);
 });
 
 test('Conversions when specified as degrees', function() {

--- a/test/js/css-angle-value.js
+++ b/test/js/css-angle-value.js
@@ -31,7 +31,7 @@ test('CSSAngleValue constructor works for valid arguments', function() {
   ];
   for (var i = 0; i < values.length; i++) {
     assert.instanceOf(values[i], CSSAngleValue);
-    assert.approximately(values[i].degrees, expectations[i].degrees, EPSILON);
+    assert.closeTo(values[i].degrees, expectations[i].degrees, EPSILON);
     assert.strictEqual(values[i]._value, expectations[i].value);
     assert.strictEqual(values[i]._unit, expectations[i].unit);
     assert.strictEqual(values[i].cssText, expectations[i].cssText);
@@ -62,32 +62,32 @@ test('Invalid unit throws', function() {
 test('Conversions when specified as degrees', function() {
   var angleValue = new CSSAngleValue(40, 'deg');
   assert.strictEqual(angleValue.degrees, 40);
-  assert.approximately(angleValue.radians, 0.698132, EPSILON);
-  assert.approximately(angleValue.gradians, 44.444444, EPSILON);
-  assert.approximately(angleValue.turns, 0.111111, EPSILON);
+  assert.closeTo(angleValue.radians, 0.698132, EPSILON);
+  assert.closeTo(angleValue.gradians, 44.444444, EPSILON);
+  assert.closeTo(angleValue.turns, 0.111111, EPSILON);
 });
 
 test('Conversions when specified as radians', function() {
   var angleValue = new CSSAngleValue(100, 'rad');
-  assert.approximately(angleValue.degrees, 5729.577951, EPSILON);
+  assert.closeTo(angleValue.degrees, 5729.577951, EPSILON);
   assert.strictEqual(angleValue.radians, 100);
-  assert.approximately(angleValue.gradians, 6366.197724, EPSILON);
-  assert.approximately(angleValue.turns, 15.915494, EPSILON);
+  assert.closeTo(angleValue.gradians, 6366.197724, EPSILON);
+  assert.closeTo(angleValue.turns, 15.915494, EPSILON);
 });
 
 test('Conversions when specified as gradians', function() {
   var angleValue = new CSSAngleValue(215, 'grad');
-  assert.approximately(angleValue.degrees, 193.5, EPSILON);
-  assert.approximately(angleValue.radians, 3.377212, EPSILON);
+  assert.closeTo(angleValue.degrees, 193.5, EPSILON);
+  assert.closeTo(angleValue.radians, 3.377212, EPSILON);
   assert.strictEqual(angleValue.gradians, 215);
-  assert.approximately(angleValue.turns, 0.5375, EPSILON);
+  assert.closeTo(angleValue.turns, 0.5375, EPSILON);
 });
 
 test('Conversions when specified as turns', function() {
   var angleValue = new CSSAngleValue(0.6, 'turn');
-  assert.approximately(angleValue.degrees, 216, EPSILON);
-  assert.approximately(angleValue.radians, 3.769911, EPSILON);
-  assert.approximately(angleValue.gradians, 240, EPSILON);
+  assert.closeTo(angleValue.degrees, 216, EPSILON);
+  assert.closeTo(angleValue.radians, 3.769911, EPSILON);
+  assert.closeTo(angleValue.gradians, 240, EPSILON);
   assert.strictEqual(angleValue.turns, 0.6);
 });
 
@@ -102,7 +102,7 @@ test('Parsing valid strings results in expected CSSAngleValues', function() {
     var result = typedOM.internal.parsing.consumeAngleValue(values[i].str);
     assert.isNotNull(result, 'Failed parsing ' + values[i].str);
     assert.instanceOf(result[0], CSSAngleValue);
-    assert.approximately(result[0].degrees, values[i].degrees, EPSILON);
+    assert.closeTo(result[0].degrees, values[i].degrees, EPSILON);
     assert.strictEqual(result[0]._value, values[i].value);
     assert.strictEqual(result[0]._unit, values[i].unit);
     assert.strictEqual(result[0].cssText, values[i].cssText);
@@ -120,7 +120,7 @@ test('Parsing is case insensitive', function() {
     var result = typedOM.internal.parsing.consumeAngleValue(values[i].str);
     assert.isNotNull(result, 'Failed parsing ' + values[i].str);
     assert.instanceOf(result[0], CSSAngleValue);
-    assert.approximately(result[0].degrees, values[i].degrees, EPSILON);
+    assert.closeTo(result[0].degrees, values[i].degrees, EPSILON);
     assert.strictEqual(result[0]._value, values[i].value);
     assert.strictEqual(result[0]._unit, values[i].unit);
     assert.strictEqual(result[0].cssText, values[i].cssText);

--- a/test/js/css-color-value.js
+++ b/test/js/css-color-value.js
@@ -15,37 +15,33 @@
 suite('CSSColorValue', function() {
   test('Constructor should throw an error if r, g and b are not integers', function() {
     assert.doesNotThrow(function() {new CSSColorValue(0, 50, 255);});
-    assert.throw(function() {new CSSColorValue(0, "lemon", 50);}, TypeError,
-      'r, g and b must be integers.');
-    assert.throw(function() {new CSSColorValue(0, 50, null);}, TypeError,
-      'r, g and b must be integers.');
-    assert.throw(function() {new CSSColorValue(50.5, 20, 50);}, TypeError,
-      'r, g and b must be integers.');
+
+    var integerErr = /^r, g and b must be integers\.$/;
+    assert.throws(function() {new CSSColorValue(0, "lemon", 50);}, TypeError, integerErr);
+    assert.throws(function() {new CSSColorValue(0, 50, null);}, TypeError, integerErr);
+    assert.throws(function() {new CSSColorValue(50.5, 20, 50);}, TypeError, integerErr);
   });
 
   test('Constructor should throw an error if r, g and b are not between 0 and 255', function() {
-    assert.throw(function() {new CSSColorValue(0, -1, 50, 0);}, TypeError,
-      'r, g and b must be integers between 0 and 255.');
-    assert.throw(function() {new CSSColorValue(0, 255, 256);}, TypeError,
-      'r, g and b must be integers between 0 and 255.');
-    assert.throw(function() {new CSSColorValue(300, 255, 256);}, TypeError,
-      'r, g and b must be integers between 0 and 255.');
+    var rangeErr = /^r, g and b must be integers between 0 and 255\.$/;
+    assert.throws(function() {new CSSColorValue(0, -1, 50, 0);}, TypeError, rangeErr);
+    assert.throws(function() {new CSSColorValue(0, 255, 256);}, TypeError, rangeErr);
+    assert.throws(function() {new CSSColorValue(300, 255, 256);}, TypeError, rangeErr);
   });
 
   test('Constructor should throw an error if a is not a number', function() {
-    assert.throw(function() {new CSSColorValue(0, 50, 50, "lemon");}, TypeError,
-      'a must be a number.');
-    assert.throw(function() {new CSSColorValue(0, 50, 50, null);}, TypeError,
-      'a must be a number.');
+    var numberErr = /^a must be a number\.$/;
+    assert.throws(function() {new CSSColorValue(0, 50, 50, "lemon");}, TypeError, numberErr);
+    assert.throws(function() {new CSSColorValue(0, 50, 50, null);}, TypeError, numberErr);
   });
 
   test('Constructor should throw an error if a is not between 0 and 1', function() {
     assert.doesNotThrow(function() {new CSSColorValue(0, 50, 255, 1);});
     assert.doesNotThrow(function() {new CSSColorValue(0, 50, 255, 0);});
-    assert.throw(function() {new CSSColorValue(0, 50, 50, -0.1);}, TypeError,
-      'a must be a number between 0 and 1.');
-    assert.throw(function() {new CSSColorValue(0, 50, 255, 1.2);}, TypeError,
-      'a must be a number between 0 and 1.');
+
+    var rangeErr = /^a must be a number between 0 and 1\.$/;
+    assert.throws(function() {new CSSColorValue(0, 50, 50, -0.1);}, TypeError, rangeErr);
+    assert.throws(function() {new CSSColorValue(0, 50, 255, 1.2);}, TypeError, rangeErr);
   });
 
   test('cssText should return rgb(<number>,<number>,<number>) if alpha ' +

--- a/test/js/css-image-value.js
+++ b/test/js/css-image-value.js
@@ -14,7 +14,8 @@
 
 suite('CSSImageValue', function() {
   test('Can only create internal CSSImageValue object', function() {
-    assert.throw(function() { new CSSImageValue(new Image()); }, TypeError, "Can\'t instantiate CSSImageValue");
+    var instantiateErr = /^Can't instantiate CSSImageValue$/;
+    assert.throws(function() { new CSSImageValue(new Image()); }, TypeError, instantiateErr);
     assert.doesNotThrow(function() { new typedOM.internal.CSSImageValue(new Image()); });
   });
 
@@ -25,11 +26,12 @@ suite('CSSImageValue', function() {
   });
 
   test('CSSImageValue only accepts Image object', function() {
-    assert.throw(function() { new typedOM.internal.CSSImageValue(); }, TypeError, "image must be an Image object");
-    assert.throw(function() { new typedOM.internal.CSSImageValue(1); }, TypeError, "image must be an Image object");
-    assert.throw(function() { new typedOM.internal.CSSImageValue("abc"); }, TypeError, "image must be an Image object");
-    assert.throw(function() { new typedOM.internal.CSSImageValue([]); }, TypeError, "image must be an Image object");
-    assert.throw(function() { new typedOM.internal.CSSImageValue({ x: 1, y: 2 }); }, TypeError, "image must be an Image object");
+    var imageErr = /image must be an Image object/;
+    assert.throws(function() { new typedOM.internal.CSSImageValue(); }, TypeError, imageErr);
+    assert.throws(function() { new typedOM.internal.CSSImageValue(1); }, TypeError, imageErr);
+    assert.throws(function() { new typedOM.internal.CSSImageValue("abc"); }, TypeError, imageErr);
+    assert.throws(function() { new typedOM.internal.CSSImageValue([]); }, TypeError, imageErr);
+    assert.throws(function() { new typedOM.internal.CSSImageValue({ x: 1, y: 2 }); }, TypeError, imageErr);
   });
 
   test('CSSImageValue\'s state and dimensions are correct before and after loaded', function(done) {

--- a/test/js/css-resource-value.js
+++ b/test/js/css-resource-value.js
@@ -19,9 +19,10 @@ suite('CSSResourceValue', function() {
   });
 
   test('Constructor only accepts a string of CSSResourceState', function() {
-    assert.throw(function() { new CSSResourceValue(); }, TypeError, 'State of a CSSResourceValue must be one of CSSResourceState');
-    assert.throw(function() { new CSSResourceValue(1); }, TypeError, 'State of a CSSResourceValue must be one of CSSResourceState');
-    assert.throw(function() { new CSSResourceValue([1, 2]); }, TypeError, 'State of a CSSResourceValue must be one of CSSResourceState');
-    assert.throw(function() { new CSSResourceValue('undefined'); }, TypeError, 'State of a CSSResourceValue must be one of CSSResourceState');
+    var stateErr = /^State of a CSSResourceValue must be one of CSSResourceState$/;
+    assert.throws(function() { new CSSResourceValue(); }, TypeError, stateErr);
+    assert.throws(function() { new CSSResourceValue(1); }, TypeError, stateErr);
+    assert.throws(function() { new CSSResourceValue([1, 2]); }, TypeError, stateErr);
+    assert.throws(function() { new CSSResourceValue('undefined'); }, TypeError, stateErr);
   });
 });

--- a/test/js/css-scale.js
+++ b/test/js/css-scale.js
@@ -27,7 +27,7 @@ suite('CSSScale', function() {
     assert.throws(function() {new CSSScale(1)});
     assert.throws(function() {new CSSScale('1', '2')});
     assert.throws(function() {new CSSScale(3, 4, null)});
-    assert.throws(function() {new CSSScale({x:1, y:2, z:4})});
+    assert.throws(function() {new CSSScale({x: 1, y: 2, z: 4})});
   });
 
   test('CSSScale constructor works correctly for 2 arguments', function() {

--- a/test/js/css-skew.js
+++ b/test/js/css-skew.js
@@ -70,7 +70,7 @@ suite('CSSSkew', function() {
       {str: 'SkewX(1TuRn)', cssText: 'skewx(1turn)', xValue: 1, xUnit: 'turn', yValue: 0, yUnit: 'deg', remaining: ''},
       {str: 'skewx(100grad) abc', cssText: 'skewx(100grad)', xValue: 100, xUnit: 'grad', yValue: 0, yUnit: 'deg', remaining: 'abc'},
       // skewy
-      {str: 'skewy(0.45turn)', cssText: 'skewy(0.45turn)', xValue: 0, xUnit: 'deg', yValue:0.45 , yUnit: 'turn', remaining: ''},
+      {str: 'skewy(0.45turn)', cssText: 'skewy(0.45turn)', xValue: 0, xUnit: 'deg', yValue: 0.45, yUnit: 'turn', remaining: ''},
       {str: 'SkEwY(2.1RAD)', cssText: 'skewy(2.1rad)', xValue: 0, xUnit: 'deg', yValue: 2.1, yUnit: 'rad', remaining: ''},
       {str: 'skewy(20DEG))))', cssText: 'skewy(20deg)', xValue: 0, xUnit: 'deg', yValue: 20, yUnit: 'deg', remaining: ')))'},
     ];

--- a/test/js/css-translation.js
+++ b/test/js/css-translation.js
@@ -115,8 +115,8 @@ suite('CSSTranslation', function() {
       assert.strictEqual(parsed[1], values[i].remaining, values[i].str + ' expected ' + values[i].remaining + ' as trailing characters');
       assert.instanceOf(parsed[0], CSSTranslation);
       assert.isTrue(parsed[0].is2D);
-      assert.approximately(parsed[0].x.value, values[i].x, 1e-6);
-      assert.approximately(parsed[0].y.value, values[i].y, 1e-6);
+      assert.closeTo(parsed[0].x.value, values[i].x, 1e-6);
+      assert.closeTo(parsed[0].y.value, values[i].y, 1e-6);
       assert.strictEqual(parsed[0].x.type, 'px');
       assert.strictEqual(parsed[0].y.type, 'px');
       assert.strictEqual(parsed[0].z, null);
@@ -139,9 +139,9 @@ suite('CSSTranslation', function() {
       assert.strictEqual(parsed[1], values[i].remaining, values[i].str + ' expected ' + values[i].remaining + ' as trailing characters');
       assert.instanceOf(parsed[0], CSSTranslation);
       assert.isFalse(parsed[0].is2D);
-      assert.approximately(parsed[0].x.value, values[i].x, 1e-6);
-      assert.approximately(parsed[0].y.value, values[i].y, 1e-6);
-      assert.approximately(parsed[0].z.value, values[i].z, 1e-6);
+      assert.closeTo(parsed[0].x.value, values[i].x, 1e-6);
+      assert.closeTo(parsed[0].y.value, values[i].y, 1e-6);
+      assert.closeTo(parsed[0].z.value, values[i].z, 1e-6);
       assert.strictEqual(parsed[0].x.type, 'px');
       assert.strictEqual(parsed[0].y.type, 'px');
       assert.strictEqual(parsed[0].z.type, 'px');
@@ -163,8 +163,8 @@ suite('CSSTranslation', function() {
       assert.strictEqual(parsed[1], values[i].remaining, values[i].str + ' expected ' + values[i].remaining + ' as trailing characters');
       assert.instanceOf(parsed[0], CSSTranslation);
       assert.isTrue(parsed[0].is2D);
-      assert.approximately(parsed[0].x.value, values[i].x, 1e-6);
-      assert.approximately(parsed[0].y.value, values[i].y, 1e-6);
+      assert.closeTo(parsed[0].x.value, values[i].x, 1e-6);
+      assert.closeTo(parsed[0].y.value, values[i].y, 1e-6);
       assert.strictEqual(parsed[0].x.type, 'px');
       assert.strictEqual(parsed[0].y.type, 'px');
       assert.strictEqual(parsed[0].z, null);

--- a/test/js/css-unparsed-value.js
+++ b/test/js/css-unparsed-value.js
@@ -22,7 +22,7 @@ suite('CSSUnparsedValue', function() {
     var valueErr = /^CSSUnparsedValue should be an array of string or CSSVariableReferenceValue$/;
     assert.throws(function() { new CSSUnparsedValue(1); }, TypeError, valueErr);
     assert.throws(function() { new CSSUnparsedValue("123"); }, TypeError, valueErr);
-    assert.throws(function() { new CSSUnparsedValue({ h:10, w:5, d:4, t:"5" });}, TypeError, valueErr);
+    assert.throws(function() { new CSSUnparsedValue({h: 10, w: 5, d: 4, t: "5"});}, TypeError, valueErr);
   });
 
   test('Values not an array of string or CSSVariableReferenceValue throws', function() {

--- a/test/js/css-unparsed-value.js
+++ b/test/js/css-unparsed-value.js
@@ -19,19 +19,16 @@ suite('CSSUnparsedValue', function() {
   });
 
   test('Values not an array throws', function() {
-    assert.throw(function() { new CSSUnparsedValue(1); }, TypeError,
-        'CSSUnparsedValue should be an array of string or CSSVariableReferenceValue');
-    assert.throw(function() { new CSSUnparsedValue("123"); }, TypeError,
-        'CSSUnparsedValue should be an array of string or CSSVariableReferenceValue');
-    assert.throw(function() { new CSSUnparsedValue({ h:10, w:5, d:4, t:"5" });}, TypeError,
-        'CSSUnparsedValue should be an array of string or CSSVariableReferenceValue');
+    var valueErr = /^CSSUnparsedValue should be an array of string or CSSVariableReferenceValue$/;
+    assert.throws(function() { new CSSUnparsedValue(1); }, TypeError, valueErr);
+    assert.throws(function() { new CSSUnparsedValue("123"); }, TypeError, valueErr);
+    assert.throws(function() { new CSSUnparsedValue({ h:10, w:5, d:4, t:"5" });}, TypeError, valueErr);
   });
 
   test('Values not an array of string or CSSVariableReferenceValue throws', function() {
-    assert.throw(function() { new CSSUnparsedValue([1]); }, TypeError,
-        "CSSUnparsedValue\'s elements should be string or CSSVariableReferenceValue");
-    assert.throw(function() { new CSSUnparsedValue(["1234", "2342", 1]); }, TypeError,
-        "CSSUnparsedValue\'s elements should be string or CSSVariableReferenceValue");
+    var valueErr = /^CSSUnparsedValue's elements should be string or CSSVariableReferenceValue$/;
+    assert.throws(function() { new CSSUnparsedValue([1]); }, TypeError, valueErr);
+    assert.throws(function() { new CSSUnparsedValue(["1234", "2342", 1]); }, TypeError, valueErr);
   });
 
   test('Using spread operator on CSSUnparsedValue results in the correct values', function() {

--- a/test/js/css-url-image-value.js
+++ b/test/js/css-url-image-value.js
@@ -21,9 +21,10 @@ suite('CSSURLImageValue', function() {
   });
 
   test('CSSURLImageValue only accepts string', function() {
-    assert.throw(function() { new CSSURLImageValue(); }, TypeError, "URL must be a string");
-    assert.throw(function() { new CSSURLImageValue([]); }, TypeError, "URL must be a string");
-    assert.throw(function() { new CSSURLImageValue(1); }, TypeError, "URL must be a string");
+    var stringErr = /^URL must be a string$/;
+    assert.throws(function() { new CSSURLImageValue(); }, TypeError, stringErr);
+    assert.throws(function() { new CSSURLImageValue([]); }, TypeError, stringErr);
+    assert.throws(function() { new CSSURLImageValue(1); }, TypeError, stringErr);
     assert.doesNotThrow(function() { new CSSURLImageValue(''); });
   });
 

--- a/test/js/css-variable-reference-value.js
+++ b/test/js/css-variable-reference-value.js
@@ -26,11 +26,16 @@ suite('CSSVariableReferenceValue', function() {
   });
 
   test('Constructor only accepts a string and a CSSUnparsedValue', function() {
-    assert.throw(function() { new CSSVariableReferenceValue(); }, TypeError, 'CSSVariableReferenceValue constructor should get two parameters');
-    assert.throw(function() { new CSSVariableReferenceValue("123"); }, TypeError, 'CSSVariableReferenceValue constructor should get two parameters');
-    assert.throw(function() { new CSSVariableReferenceValue(1234, 1234); }, TypeError, 'Variable of CSSVariableReferenceValue must be a string');
-    assert.throw(function() { new CSSVariableReferenceValue(["1"], 1234); }, TypeError, 'Variable of CSSVariableReferenceValue must be a string');
-    assert.throw(function() { new CSSVariableReferenceValue("123", 1234); }, TypeError, 'Fallback of CSSVariableReferenceValue must be a CSSUnparsedValue');
+    var paramsErr = /^CSSVariableReferenceValue constructor should get two parameters$/;
+    assert.throws(function() { new CSSVariableReferenceValue(); }, TypeError, paramsErr);
+    assert.throws(function() { new CSSVariableReferenceValue("123"); }, TypeError, paramsErr);
+
+    var stringErr = /^Variable of CSSVariableReferenceValue must be a string$/;
+    assert.throws(function() { new CSSVariableReferenceValue(1234, 1234); }, TypeError, stringErr);
+    assert.throws(function() { new CSSVariableReferenceValue(["1"], 1234); }, TypeError, stringErr);
+
+    var fallbackErr = /^Fallback of CSSVariableReferenceValue must be a CSSUnparsedValue$/;
+    assert.throws(function() { new CSSVariableReferenceValue("123", 1234); }, TypeError, fallbackErr);
   });
 
   test('CSSVariableReferenceValue can have undefined fallback', function() {

--- a/test/js/escape.js
+++ b/test/js/escape.js
@@ -16,9 +16,8 @@ suite('CSS.escape polyfill', function() {
   var escape = typedOM.internal.escape;
 
   test('Test invalid usage', function() {
-    assert.throws(function() {
-      CSS.escape();
-    }, TypeError);
+    assert.throws(function() { CSS.escape(); }, TypeError,
+        /^Failed to execute 'escape' on 'CSS': 1 argument required, but only 0 present\.$/);
     assert.equal('null', CSS.escape(null));
     assert.equal('\\[object\\ Object\\]', CSS.escape({}));
   });

--- a/test/js/inline-style-property-map.js
+++ b/test/js/inline-style-property-map.js
@@ -57,33 +57,38 @@ suite('Inline StylePropertyMap', function() {
     var inlineStyleMap = this.element.styleMap();
     var valueSequence = [new CSSSimpleLength(3, 'px'), new CSSSimpleLength(6, 'px')];
 
-    assert.throw(function() {inlineStyleMap.set('height', valueSequence)}, TypeError, 'height does not support sequences of styleValues');
+    assert.throws(function() {inlineStyleMap.set('height', valueSequence)}, TypeError,
+      /^height does not support sequences of styleValues$/);
   });
 
   test('Set should throw a TypeError if a non CSSKeywordValue CSSStyleValue unsupported by the CSS style property is set', function() {
     var inlineStyleMap = this.element.styleMap();
     var numberValue = new CSSNumberValue(42);
 
-    assert.throw(function() {inlineStyleMap.set('height', numberValue)}, TypeError);
+    assert.throws(function() {inlineStyleMap.set('height', numberValue)}, TypeError,
+      /^height does not take values of type CSSNumberValue$/);
   });
 
   test('Set should throw a TypeError if a CSSKeywordValue unsupported by the CSS style property is set ', function() {
     var inlineStyleMap = this.element.styleMap();
     var keyword = new CSSKeywordValue('lemon');
 
-    assert.throw(function() {inlineStyleMap.set('height', keyword)}, 'height does not take the keyword lemon');
+    assert.throws(function() {inlineStyleMap.set('height', keyword)},
+      /^height does not take the keyword lemon$/);
   });
 
   test('Set should throw a TypeError if a non CSSStyleValue is inputed into the function', function() {
     var inlineStyleMap = this.element.styleMap();
 
-    assert.throw(function() {inlineStyleMap.set('height', 4)}, TypeError);
+    assert.throws(function() {inlineStyleMap.set('height', 4)}, TypeError,
+      /^height does not take values of type Number$/);
   });
 
   test('Set should throw a TypeError if an unsupported property is inputed into the function', function() {
     var inlineStyleMap = this.element.styleMap();
 
-    assert.throw(function() {inlineStyleMap.set('lemons', new CSSSimpleLength(3, 'px'))}, TypeError);
+    assert.throws(function() {inlineStyleMap.set('lemons', new CSSSimpleLength(3, 'px'))}, TypeError,
+      /^Cannot set lemons because it is not a supported CSS property$/);
   });
 
   test('The delete method clears a given property', function() {
@@ -97,7 +102,8 @@ suite('Inline StylePropertyMap', function() {
   test('The delete method should throw a TypeError if an unsupported property', function() {
     var inlineStyleMap = this.element.styleMap();
 
-    assert.throw(function() {inlineStyleMap.delete('lemons')}, TypeError);
+    assert.throws(function() {inlineStyleMap.delete('lemons')}, TypeError,
+      /^Cannot delete lemons because it is not a supported CSS property$/);
   });
 
   test('The has method will return true if the valid CSS property input has been assigned a value' +
@@ -111,7 +117,8 @@ suite('Inline StylePropertyMap', function() {
   test('The has method should throw a TypeError if an unsupported property', function() {
     var inlineStyleMap = this.element.styleMap();
 
-    assert.throw(function() {inlineStyleMap.has('lemons')}, TypeError);
+    assert.throws(function() {inlineStyleMap.has('lemons')}, TypeError,
+      /^Cannot use has method for lemons because it is not a supported CSS property$/);
   });
 
   test('The append method should successfully append a supported CSSStyleValue to a property ' +
@@ -149,29 +156,29 @@ suite('Inline StylePropertyMap', function() {
     var valueSequence = [new CSSNumberValue(4), new CSSNumberValue(5), new CSSSimpleLength(3, 'px'), new CSSKeywordValue('infinite')];
     this.element.style['animation-iteration-count'] = 'infinite, 2, 5';
 
-    assert.throw(function() {inlineStyleMap.append('animation-iteration-count', valueSequence)}, TypeError,
-      'animation-iteration-count does not take values of type CSSSimpleLength');
+    assert.throws(function() {inlineStyleMap.append('animation-iteration-count', valueSequence)}, TypeError,
+      /^animation-iteration-count does not take values of type CSSSimpleLength$/);
   });
 
   test('The append method should throw a TypeError when an unsupported CSS property is entered', function() {
     var inlineStyleMap = this.element.styleMap();
 
-    assert.throw(function() {inlineStyleMap.append('lemon', new CSSNumberValue(4))}, TypeError,
-      'lemon is not a supported CSS property');
+    assert.throws(function() {inlineStyleMap.append('lemon', new CSSNumberValue(4))}, TypeError,
+      /^lemon is not a supported CSS property$/);
   });
 
   test('The append method should throw a TypeError when a CSS property that does not support list values is entered', function() {
     var inlineStyleMap = this.element.styleMap();
 
-    assert.throw(function() {inlineStyleMap.append('height', new CSSNumberValue(4))}, TypeError,
-      'height does not support sequences of styleValues');
+    assert.throws(function() {inlineStyleMap.append('height', new CSSNumberValue(4))}, TypeError,
+      /^height does not support sequences of styleValues$/);
   });
 
   test('The append method should throw a TypeError when null is entered as the value', function() {
     var inlineStyleMap = this.element.styleMap();
 
-    assert.throw(function() {inlineStyleMap.append('animation-iteration-count', null)}, TypeError,
-      'null cannot be appended to CSS properties');
+    assert.throws(function() {inlineStyleMap.append('animation-iteration-count', null)}, TypeError,
+      /^null cannot be appended to CSS properties$/);
   });
 
   test('getProperties returns an ordered list of properties that have been set on an element', function() {

--- a/test/js/property-dictionary.js
+++ b/test/js/property-dictionary.js
@@ -77,7 +77,7 @@ suite('PropertyDictionary', function() {
 
   test('listValueSeparator method should throw a TypeError if the property entered does not support list values', function() {
 
-    assert.throw(function () {cssPropertyDictionary.listValueSeparator('height')}, TypeError);
+    assert.throws(function () {cssPropertyDictionary.listValueSeparator('height')}, TypeError, /^height does not support lists of CSSStyleValues$/);
   });
 
   test('supportedStyleValues should return an array of constructors for all CSSStyleValue types accepted by that property', function() {
@@ -88,6 +88,6 @@ suite('PropertyDictionary', function() {
 
   test('supportedStyleValues should throw a type error for unsupported properties', function() {
 
-    assert.throw(function () {cssPropertyDictionary.supportedStyleValues('lemon');}, TypeError);
+    assert.throws(function () {cssPropertyDictionary.supportedStyleValues('lemon');}, TypeError, /^lemon is not a supported CSS property$/);
   });
 });


### PR DESCRIPTION
Cleans up tests code. Uses `assert.throws`, not `throw`; changes to `closeTo` from `approximate`.

Also adds regex error matching, including adding a few message matches where there were none.
