### PR TITLE
Hide CSSUnparsedValue's constructor

### DIFF
--- a/src/css-unparsed-value.js
+++ b/src/css-unparsed-value.js
@@ -53,8 +53,7 @@
     function CSSUnparsedValue(values) {
       if (values == undefined) {
         values = [];
-      }
-      if (!Array.isArray(values)) {
+      } else if (!Array.isArray(values)) {
         throw new TypeError('CSSUnparsedValue should be an array of string or CSSVariableReferenceValue');
       }
       for (var i = 0; i < values.length; i++) {

--- a/src/css-unparsed-value.js
+++ b/src/css-unparsed-value.js
@@ -15,18 +15,7 @@
 (function(internal, scope) {
 
   function CSSUnparsedValue(values) {
-    if (values == undefined) {
-      values = [];
-    }
-    if (!Array.isArray(values)) {
-      throw new TypeError('CSSUnparsedValue should be an array of string or CSSVariableReferenceValue');
-    }
-    for (var i = 0; i < values.length; i++) {
-      if (typeof values[i] != 'string' && !(values[i] instanceof CSSVariableReferenceValue)) {
-        throw new TypeError("CSSUnparsedValue's elements should be string or CSSVariableReferenceValue");
-      }
-    }
-    this._listOfReferences = values;
+    throw new TypeError('CSSUnparsedValue cannot be instantiated.');
   }
   internal.inherit(CSSUnparsedValue, CSSStyleValue);
 
@@ -59,5 +48,25 @@
   };
 
   scope.CSSUnparsedValue = CSSUnparsedValue;
+
+  (function() {
+    function CSSUnparsedValue(values) {
+      if (values == undefined) {
+        values = [];
+      }
+      if (!Array.isArray(values)) {
+        throw new TypeError('CSSUnparsedValue should be an array of string or CSSVariableReferenceValue');
+      }
+      for (var i = 0; i < values.length; i++) {
+        if (typeof values[i] != 'string' && !(values[i] instanceof CSSVariableReferenceValue)) {
+          throw new TypeError("CSSUnparsedValue's elements should be string or CSSVariableReferenceValue");
+        }
+      }
+      this._listOfReferences = values;
+    }
+    CSSUnparsedValue.prototype = Object.create(scope.CSSUnparsedValue.prototype);
+
+    internal.CSSUnparsedValue = CSSUnparsedValue;
+  })();
 
 })(typedOM.internal, window);

--- a/test/js/css-unparsed-value.js
+++ b/test/js/css-unparsed-value.js
@@ -13,27 +13,32 @@
 // limitations under the License.
 
 suite('CSSUnparsedValue', function() {
+  test('Cannot instantiate CSSUnparsedValue', function() {
+    assert.throws(function() { new CSSUnparsedValue(); },
+        /^CSSUnparsedValue cannot be instantiated/);
+  });
+
   test("CSSUnparsedValue is a CSSUnparsedValue and CSSStyleValue", function() {
-    assert.instanceOf(new CSSUnparsedValue(), CSSUnparsedValue);
-    assert.instanceOf(new CSSUnparsedValue(), CSSStyleValue);
+    assert.instanceOf(new typedOM.internal.CSSUnparsedValue(), CSSUnparsedValue);
+    assert.instanceOf(new typedOM.internal.CSSUnparsedValue(), CSSStyleValue);
   });
 
   test('Values not an array throws', function() {
     var valueErr = /^CSSUnparsedValue should be an array of string or CSSVariableReferenceValue$/;
-    assert.throws(function() { new CSSUnparsedValue(1); }, TypeError, valueErr);
-    assert.throws(function() { new CSSUnparsedValue("123"); }, TypeError, valueErr);
-    assert.throws(function() { new CSSUnparsedValue({h: 10, w: 5, d: 4, t: "5"});}, TypeError, valueErr);
+    assert.throws(function() { new typedOM.internal.CSSUnparsedValue(1); }, TypeError, valueErr);
+    assert.throws(function() { new typedOM.internal.CSSUnparsedValue("123"); }, TypeError, valueErr);
+    assert.throws(function() { new typedOM.internal.CSSUnparsedValue({h: 10, w: 5, d: 4, t: "5"});}, TypeError, valueErr);
   });
 
   test('Values not an array of string or CSSVariableReferenceValue throws', function() {
     var valueErr = /^CSSUnparsedValue's elements should be string or CSSVariableReferenceValue$/;
-    assert.throws(function() { new CSSUnparsedValue([1]); }, TypeError, valueErr);
-    assert.throws(function() { new CSSUnparsedValue(["1234", "2342", 1]); }, TypeError, valueErr);
+    assert.throws(function() { new typedOM.internal.CSSUnparsedValue([1]); }, TypeError, valueErr);
+    assert.throws(function() { new typedOM.internal.CSSUnparsedValue(["1234", "2342", 1]); }, TypeError, valueErr);
   });
 
   test('Using spread operator on CSSUnparsedValue results in the correct values', function() {
-    var values = ['string', new CSSVariableReferenceValue('val', new CSSUnparsedValue(['innerStr']))];
-    var tokenStream = new CSSUnparsedValue(values);
+    var values = ['string', new CSSVariableReferenceValue('val', new typedOM.internal.CSSUnparsedValue(['innerStr']))];
+    var tokenStream = new typedOM.internal.CSSUnparsedValue(values);
 
     var expected = [[0, values[0]], [1, values[1]]];
     var result = [...tokenStream];
@@ -42,10 +47,10 @@ suite('CSSUnparsedValue', function() {
   });
 
   test('Using iterator operations on entries() gets correct values', function() {
-    var values = ['test', new CSSVariableReferenceValue('var', new CSSUnparsedValue(['1']))];
+    var values = ['test', new CSSVariableReferenceValue('var', new typedOM.internal.CSSUnparsedValue(['1']))];
     var expectedEntries = [[0, values[0]], [1, values[1]]];
 
-    var tokenStreamValue = new CSSUnparsedValue(values);
+    var tokenStreamValue = new typedOM.internal.CSSUnparsedValue(values);
 
     // One by one
     assert.deepEqual(
@@ -60,9 +65,9 @@ suite('CSSUnparsedValue', function() {
   });
 
   test('Using iterator operations on keys() gets correct values', function() {
-    var values = ['test', new CSSVariableReferenceValue('var', new CSSUnparsedValue(['1']))];
+    var values = ['test', new CSSVariableReferenceValue('var', new typedOM.internal.CSSUnparsedValue(['1']))];
     var expectedKeys = [0, 1];
-    var tokenStreamValue = new CSSUnparsedValue(values);
+    var tokenStreamValue = new typedOM.internal.CSSUnparsedValue(values);
 
     // One by one
     assert.deepEqual(
@@ -77,8 +82,8 @@ suite('CSSUnparsedValue', function() {
   });
 
   test('Using iterator operations on values() gets correct values', function() {
-    var inputValues = ['test', new CSSVariableReferenceValue('var', new CSSUnparsedValue(['1']))];
-    var tokenStreamValue = new CSSUnparsedValue(inputValues);
+    var inputValues = ['test', new CSSVariableReferenceValue('var', new typedOM.internal.CSSUnparsedValue(['1']))];
+    var tokenStreamValue = new typedOM.internal.CSSUnparsedValue(inputValues);
     // One by one
     assert.deepEqual(
         iteratorExpansionUsingNext(tokenStreamValue.values()),

--- a/test/js/css-variable-reference-value.js
+++ b/test/js/css-variable-reference-value.js
@@ -15,7 +15,7 @@
 suite('CSSVariableReferenceValue', function() {
   test('The new CSSVariableReferenceValue attributes are correct', function() {
     var expectedVariable = 'anything';
-    var expectedFallback = new CSSUnparsedValue(["123"]);
+    var expectedFallback = new typedOM.internal.CSSUnparsedValue(["123"]);
     var referenceValue = new CSSVariableReferenceValue(expectedVariable, expectedFallback);
     assert.instanceOf(referenceValue, CSSVariableReferenceValue,
       'A new CSSVariableReferenceValue should be an instance of CSSVariableReferenceValue');


### PR DESCRIPTION
It shouldn't be instantiable by users.
